### PR TITLE
Remove stale advice from README.md

### DIFF
--- a/review-tools/README
+++ b/review-tools/README
@@ -23,8 +23,7 @@ addrev
 
 addrev is a simple pair of scripts to add or edit reviewers to commits.
 
-To use add the scripts gitaddrev and addrev to your PATH and edit
-gitaddrev to contain your email address.
+To use add the scripts gitaddrev and addrev to your PATH.
 
 Usage is
 


### PR DESCRIPTION
After commit 8909d2161299bafbdb0690cdf8b677c0ce7c2f34, gitaddrev
uses OpenSSL::Query to determine valid reviewers, so there is no
longer a hardcoded list to update.