### PR TITLE
ghmerge: improve error handling

### DIFF
--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -71,7 +71,7 @@ addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..
 git checkout $REL
 if [ "$MERGE" == "yes" ] ; then
     git merge --no-commit --squash $WORK
-    AUTHOR=`git show --no-patch --pretty=format:%an <%ae> $WORK`
+    AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
 else
     git rebase $WORK

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -o errexit
+
 if [ ! -d .git ] ; then
     echo Not at top-level
     exit 1
@@ -31,17 +33,34 @@ esac
 
 curl -s https://api.github.com/repos/openssl/openssl/pulls/$PRNUM >/tmp/gh$$
 TEAM=$*
-set `python -c '
+set -- `python -c '
+from __future__ import print_function
 import json, sys;
-print str(json.load(sys.stdin)["head"]["label"]).replace(":", " ")' </tmp/gh$$`
+print(str(json.load(sys.stdin)["head"]["label"]).replace(":", " "))' </tmp/gh$$`
 rm /tmp/gh$$
 WHO=$1
 BRANCH=$2
 
-REL=`git branch | fgrep '*' | tr -d '* '`
+if [ -z "$WHO" -o -z "$BRANCH" ]; then
+    echo "Don't know from which branch to fetch"
+    exit 1
+fi
+
+REL=`git rev-parse --abbrev-ref HEAD`
 WORK="${WHO}-${BRANCH}"
+PREV=
 
 git checkout -b $WORK $REL
+
+function cleanup {
+	if [ "$WORK" != "$REL" ]; then
+		git checkout -q $REL
+		git branch -D $WORK
+	fi
+}
+trap 'cleanup' EXIT
+
+
 git pull --rebase https://github.com/$WHO/openssl.git $BRANCH
 git rebase $REL
 echo Diff against $REL
@@ -72,5 +91,3 @@ done
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
     git push origin $REL
 fi
-
-git branch -D $WORK

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -53,10 +53,10 @@ PREV=
 git checkout -b $WORK $REL
 
 function cleanup {
-	if [ "$WORK" != "$REL" ]; then
-		git checkout -q $REL
-		git branch -D $WORK
-	fi
+    if [ "$WORK" != "$REL" ]; then
+        git checkout -q $REL
+        git branch -D $WORK
+    fi
 }
 trap 'cleanup' EXIT
 


### PR DESCRIPTION
When python3 is the default python interpreter, the embedded script fails with a syntax error at the print statement. In the absence of error checking, this leads to a cascade of unhandled errors, ending up in an empty pager window. Here an example:

```
ghmerge prnum reviewer1 reviewer2
```

- the empty output of the python command causes the env command to print the (named and positional) parameters instead of clearing $1 and $2.  Consequently, the script assigns WHO=reviewer1 and BRANCH=reviewer2.

- git checks out a local branch reviewer1-reviewer2 and tries to pull  from `https://github.com/reviewer1/openssl.git reviewer2`  This call fails, and again the error is ignored.

- The call `git diff reviewer1-reviewer2` leads to the empty pager window, since git has no diffs to show.


### Countermeasures

- make the python script work for python2 and python3
- add a break-on-error statement (`set -o errexit`, aka `set -e`)
- replace `set` by `set --` which changes the behaviour of the set command as desired (see `man set`).
- add an explicit check for $WHO and $BRANCH
- add an exit trap for cleaning up the branch



### Trancript before the fix

```
$ ghmerge 4998 mspncp paulidale

+ '[' '!' -d .git ']'
+ TRIVIAL=
+ '[' 4998 == --trivial ']'
+ MERGE=yes
+ '[' 4998 == --merge -o 4998 == --squash ']'
+ '[' 4998 == --nomerge -o 4998 == --nosquash ']'
+ '[' 3 -lt 2 ']'
+ PRNUM=4998
+ shift
+ case "$PRNUM" in
+ curl -s https://api.github.com/repos/openssl/openssl/pulls/4998
+ TEAM='mspncp paulidale'
++ python -c '
import json, sys;
print str(json.load(sys.stdin)["head"]["label"]).replace(":", " ")'
  File "<string>", line 3
    print str(json.load(sys.stdin)["head"]["label"]).replace(":", " ")
            ^
SyntaxError: invalid syntax
+ set
ANT_HOME=/usr/share/ant
BASH=/bin/bash
BASHOPTS=cmdhist:complete_fullquote:extquote:force_fignore:hostcomplete:interactive_comments:progcomp:promptvars:sourcepath

[ ... rest of environment dump omitted ... ]

+ rm /tmp/gh11724
+ WHO=mspncp
+ BRANCH=paulidale
++ git branch
++ fgrep '*'
++ tr -d '* '
+ REL=mspncp-paulidale
+ WORK=mspncp-paulidale
+ git checkout -b mspncp-paulidale mspncp-paulidale
fatal: A branch named 'mspncp-paulidale' already exists.
+ git pull --rebase https://github.com/mspncp/openssl.git paulidale
fatal: Couldn't find remote ref paulidale
+ git rebase mspncp-paulidale
Current branch mspncp-paulidale is up to date.
+ echo Diff against mspncp-paulidale
Diff against mspncp-paulidale
+ git diff mspncp-paulidale
+ echo -n Press return to merge to mspncp-paulidale and build:
Press return to merge to mspncp-paulidale and build:+ read foo
```


### Trancript after the fix

```
+ set -o errexit
+ '[' '!' -d .git ']'
+ TRIVIAL=
+ '[' 4998 == --trivial ']'
+ MERGE=yes
+ '[' 4998 == --merge -o 4998 == --squash ']'
+ '[' 4998 == --nomerge -o 4998 == --nosquash ']'
+ '[' 3 -lt 2 ']'
+ PRNUM=4998
+ shift
+ case "$PRNUM" in
+ curl -s https://api.github.com/repos/openssl/openssl/pulls/4998
+ TEAM='mspncp paulidale'
++ python -c '
from __future__ import print_function
import json, sys;
print(str(json.load(sys.stdin)["head"]["label"]).replace(":", " "))'
+ set -- mspncp pr-restore-generic-drbg-implementation
+ rm /tmp/gh8776
+ WHO=mspncp
+ BRANCH=pr-restore-generic-drbg-implementation
+ '[' -z mspncp -o -z pr-restore-generic-drbg-implementation ']'
++ git rev-parse --abbrev-ref HEAD
+ REL=master
+ WORK=mspncp-pr-restore-generic-drbg-implementation
+ PREV=
+ git checkout -b mspncp-pr-restore-generic-drbg-implementation master
Switched to a new branch 'mspncp-pr-restore-generic-drbg-implementation'
+ trap cleanup EXIT
+ git pull --rebase https://github.com/mspncp/openssl.git pr-restore-generic-drbg-implementation
fatal: Couldn't find remote ref pr-restore-generic-drbg-implementation
+ cleanup
+ '[' mspncp-pr-restore-generic-drbg-implementation '!=' master ']'
+ git checkout -q master
+ git branch -D mspncp-pr-restore-generic-drbg-implementation
Deleted branch mspncp-pr-restore-generic-drbg-implementation (was 3e524bf2d1).
```