### PR TITLE
Fix run-checker-autohooks

### DIFF
--- a/run-checker/run-checker-autohooks/README
+++ b/run-checker/run-checker-autohooks/README
@@ -30,13 +30,13 @@ In addition to the hooks, one can also have a shell script called
 
 - REPORT_FROM
 
-  The email address used in the report From: header.  Defaults to
-  'OpenSSL run-checker <openssl@openssl.org>'
+  The email address used in the report From: header.  This MUST be
+  assigned a value or reports will not be posted.
 
 - REPORT_RECIPIENT
 
-  The email address reports will get sent to.  Defaults to
-  '<openssl-commits@openssl.org>'
+  The email address reports will get sent to.  This MUST be assigned a
+  value or reports will not be posted.
 
 - SKIP_OPTS
 

--- a/run-checker/run-checker-autohooks/README
+++ b/run-checker/run-checker-autohooks/README
@@ -9,11 +9,11 @@ repeatedly, for example as a cron job.
 
 Example setup:
 
-    $ git clone openssl-git@git.openssl.org:bureau.git bureau
+    $ git clone git://git.openssl.org/tools.git tools
     $ mkdir ~/run-checker
     $ cd ~/run-checker
-    $ ln -s ../bureau/run-checker.sh \
-      	    ../bureau/run-checker-autohooks/hook-{prepare,start,end,takedown} \
+    $ ln -s ../tools/run-checker/run-checker.sh \
+            ../tools/run-checker/run-checker-autohooks/hook-{prepare,start,end,takedown} \
 	    .
     $ git clone openssl-git@git.openssl.org:openssl.git openssl
 

--- a/run-checker/run-checker-autohooks/hook-end
+++ b/run-checker/run-checker-autohooks/hook-end
@@ -3,8 +3,8 @@
 here=$(cd $(dirname $0); pwd)
 rcd=$here/.run-checker-data
 
-REPORT_RECIPIENT='<openssl-commits@openssl.org>'
-REPORT_FROM='OpenSSL run-checker <openssl@openssl.org>'
+REPORT_RECIPIENT=
+REPORT_FROM=
 if [ -f $rcd/new/hook-config ]; then
     . $rcd/new/hook-config
 fi
@@ -38,47 +38,49 @@ if (
 
     # If the build failed or the status changed since last time, report
     if [ "$newstatus" == "fail" -o "$newstatus" != "$curstatus" ]; then
-        (
-            statusword=FAILED
-            if [ "$newstatus" == "pass" ]; then
-                statusword=SUCCESSFUL
-            elif [ "$curstatus" == "fail" ]; then
-                statusword="Still FAILED"
-            fi
-            echo "From: $REPORT_FROM"
-            echo "To: $REPORT_RECIPIENT"
-            echo "Subject: $statusword build of OpenSSL branch $gitbranch with options $expandedopts"
-            cat <<EOF
+	if [ -n "$REPORT_FROM" -a -n "$REPORT_RECIPIENT" ]; then
+            (
+		statusword=FAILED
+		if [ "$newstatus" == "pass" ]; then
+                    statusword=SUCCESSFUL
+		elif [ "$curstatus" == "fail" ]; then
+                    statusword="Still FAILED"
+		fi
+		echo "From: $REPORT_FROM"
+		echo "To: $REPORT_RECIPIENT"
+		echo "Subject: $statusword build of OpenSSL branch $gitbranch with options $expandedopts"
+		cat <<EOF
 
 Platform and configuration command:
 
 EOF
-            echo "\$ uname -a"
-            uname -a
-            head -1 "$newoptdir/build.log"
-            if [ -f $rcd/new/rc-force-build ]; then
-                cat <<EOF
+		echo "\$ uname -a"
+		uname -a
+		head -1 "$newoptdir/build.log"
+		if [ -f $rcd/new/rc-force-build ]; then
+                    cat <<EOF
 
 Forced build, latest commit is:
 
 EOF
-            else
-                cat <<EOF
+		else
+                    cat <<EOF
 
 Commit log since last time:
 
 EOF
-            fi
-            cat "$newoptdir/log"
-	    if [ "$newstatus" == "fail" ]; then
-		cat <<EOF
+		fi
+		cat "$newoptdir/log"
+		if [ "$newstatus" == "fail" ]; then
+		    cat <<EOF
 
 Build log ended with (last 100 lines):
 
 EOF
-		tail -100 "$newoptdir/build.log"
-	    fi
-        ) | /usr/lib/sendmail -it
+		    tail -100 "$newoptdir/build.log"
+		fi
+            ) | /usr/lib/sendmail -it
+	fi
     fi
 
     if [ -d "$curoptdir" ]; then


### PR DESCRIPTION
The README wasn't updated from the time this was an internal set of scripts.  Also, REPORT_FROM and REPORT_RECIPIENT were still holding internal values.  Clearing these things make these hooks ready for public consumption.