### PR TITLE
Fix do-copyright-year

### DIFF
--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -32,8 +32,7 @@ echo Updating copryight
 git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD \
 	| while read STATUS FILE ; do
     if [ "$STATUS" = 'D' ]; then continue; fi
-    sed -E -f /tmp/sed$$ "$FILE" >/tmp/$$
-    mv /tmp/$$ "$FILE"
+    sed -E -f /tmp/sed$$ -i "$FILE"
     git add "$FILE"
 done
 echo Committing change locally.

--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -29,8 +29,9 @@ EOF
 
 NYD=`date +%Y-01-01`
 echo Updating copryight
-git diff-tree -r --name-only `git rev-list -1 --before=$NYD HEAD`..HEAD \
-	| while read FILE ; do
+git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD \
+	| while read STATUS FILE ; do
+    if [ "$STATUS" = 'D' ]; then continue; fi
     sed -E -f /tmp/sed$$ "$FILE" >/tmp/$$
     mv /tmp/$$ "$FILE"
     git add "$FILE"


### PR DESCRIPTION
It recreated deleted files (made them empty) and changed permissions on executable scripts.