### PR TITLE
CC default fix

### DIFF
--- a/review-tools/opensslbuild
+++ b/review-tools/opensslbuild
@@ -21,7 +21,7 @@ test "$1" = "-x" && {
 }
 
 # Set compiler
-test "$CC" = "" && CC="ccache clang-3.6"
+test "$CC" = "" && export CC="ccache clang-3.6"
 
 # Set basic config arguments
 CONFIGARGS="-d --strict-warnings --prefix=/usr/local/openssl"


### PR DESCRIPTION
The default for CC wasn't exporting the environment variable.  Likewise, the variable wasn't used.  Hence it didn't take effect.

This fixes the issue by exporting the environment variable in this case.
