### PR TITLE
The "tls13downgrade" Configure option no longer exists

### DIFF
--- a/run-checker/run-checker.sh
+++ b/run-checker/run-checker.sh
@@ -31,7 +31,7 @@ no-err no-filenames
 no-aria no-asan no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng
 no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer
 no-heartbeats no-md2 no-msan no-rc5 no-sctp no-ssl no-ssl-trace no-tests
-no-tls13downgrade no-ubsan no-ui-console no-unit-test no-weak-ssl-ciphers
+no-ubsan no-ui-console no-unit-test no-weak-ssl-ciphers
 no-zlib no-zlib-dynamic
 enable-fuzz-afl enable-fuzz-libfuzzer enable-heartbeats no-hw no-hw-padlock
 no-idea no-makedepend enable-md2 no-md4 no-mdc2 no-gost no-multiblock


### PR DESCRIPTION
So, we need to remove checking of it from run-checker.