### PR TITLE
gitaddrev: don't lowercase the reviewers

### DIFF
--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -31,7 +31,7 @@ my @unknown_reviewers;
 my $skip_reviewer;
 my $omccount = 0;
 sub try_add_reviewer {
-    my $id = lc(shift);
+    my $id = shift;
     my $rc = undef;
     my $id2 = $id =~ /^\@(.*)$/ ? { github => $1 } : $id;
     my $rev = $query->find_person_tag($id2, 'rev');


### PR DESCRIPTION
If we lowercase them, the occasional registered mixed case ID will not
be recognised.