### PR TITLE
release-tools: use 'make tar' instead of 'make dist'

### DIFF
--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -276,7 +276,7 @@ or if you want to use the openssl-team key:
 
 Make the release tarball. You do this with:
 
-        make dist
+        make tar
 
 Create .sha1, .sha256 and .asc files manually. You can use:
 

--- a/release-tools/mkrelease.pl
+++ b/release-tools/mkrelease.pl
@@ -257,7 +257,7 @@ if ( !$no_release ) {
     my $gpgann = $ENV{"OPENSSL_GPG_ANNOUNCE"}
       // "$gpg --use-agent -sta --clearsign";
     my $tarfile = "openssl-${expected_version}.tar.gz";
-    system("(./config; make $TAR dist) >../$tarfile.log 2>&1");
+    system("(./config; make $TAR tar) >../$tarfile.log 2>&1");
     die "Error generating release!" if $?;
     die "Can't find tarball!!" unless -f "../$tarfile";
 


### PR DESCRIPTION
'make dist' will pre-configure the OpenSSL source for distribution
with a simple generic configuration, which is nice...  as long as
you're on Unix.

Unfortunately, the resulting Makefile will be picked up by NMAKE (on
Windows) and MMS / MMK (on VMS) and will spew out errors because those
are very different environments.

Therefore, it's better not to pre-configure, and just create an
archive from the source proper.

(note that pre-configuration would still work on the 1.0.2 series,
since the Windows and VMS builds are entirely different there, but
it's no big loss to force everyone to configure when using 1.0.2 as
well)