### PR TITLE
cherry-checker: initial commit

### DIFF
--- a/review-tools/cherry-checker
+++ b/review-tools/cherry-checker
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import re
+import sys
+
+left  = "master"
+right = "OpenSSL_1_1_1-stable"
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description = """Shows the commits in '{left}...{right}'
+        which are eligible for cherry-picking. A commit is considered
+        cherry-picked, if there is another commit on the "other side"
+        which introduces an equivalent patch.
+        For details, see the documentation of the '--cherry-mark' option
+        in the git-log(1) manpage.
+        """.format(left=left, right=right))
+
+    parser.add_argument(
+        '-a', '--all',
+        action = 'store_true',
+        help = "Show all commits, also those which have been cherry-picked."\
+        )
+
+    parser.add_argument(
+        '-s', '--sort',
+        action = 'store_true',
+        help = "Sort commits w.r.t. pull request number and author date."\
+        )
+
+    parser.add_argument(
+        '-r', '--remote',
+        action = 'store_true',
+        help = "Compare the remote branches instead of the local ones."\
+        )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def check_openssl_git_repo():
+    """Checks whether we're inside a openssl.git downstrem repository"""
+    try:
+        if "/openssl.git" in subprocess.check_output(
+                ["git", "remote", "-v"]
+        ).decode():
+            return True;
+    except:
+        pass
+
+    return False
+
+
+def get_remote():
+    try:
+        return subprocess.check_output(
+            ["git", "config", "branch.master.remote"]
+            ).decode().trim()
+    except:
+        return "origin"
+
+
+def pick_cherries(left, right, all = False):
+    """Lists all commits from the symmetric difference of left and right
+
+    By default, all commits are omitted which have an 'equivalent' commit
+    on the other side, unless 'all' == True.
+    """
+
+    git_command = [
+        "git", "log", "--oneline", "--cherry-mark", "--left-right",
+        left + "..." + right, "--pretty=%at;%m;%h;%s"
+    ]
+
+    regex   = re.compile("|".join([
+        # The standard pull request annotation
+        "\(Merged from https://github.com/openssl/openssl/pull/([0-9]+)\)",
+        # @kroeck's special pull request annotation ;-)
+        "GH: #([0-9]+)"
+    ]))
+
+    for line in subprocess.check_output(git_command).decode().splitlines():
+
+        timestamp, branch, commit, subject = line.split(";")
+
+        if branch == '=' and not all:
+            continue
+
+        # shorten overlong subject lines
+        if len(subject) > 70:
+            subject = subject[:70] + "..."
+
+        # search commit message for pull request number
+        message = subprocess.check_output(
+            ["git", "show", "--no-patch", commit]
+        ).decode()
+
+        match = regex.search(message)
+        if match:
+            if match.group(1):
+                prnum = match.group(1)
+            else:
+                prnum = match.group(2)
+        else:
+            prnum = "????"
+
+        yield prnum, timestamp, branch, commit, subject
+
+
+
+if __name__ == '__main__':
+    args = parse_arguments()
+
+    if not check_openssl_git_repo():
+        print("cherry-checker: Not inside an openssl git repository.", file=sys.stderr)
+        sys.exit(1)
+
+
+    if args.remote:
+        remote = get_remote()
+        left  = remote+"/"+left
+        right = remote+"/"+right
+
+    commits = pick_cherries(left, right, args.all)
+
+    if args.sort:
+        commits = sorted(commits, reverse=True)
+
+    print("""These cherries are hanging on the git-tree:
+
+  <-  {left}
+  ->  {right}
+  ==  both
+
+ prnum | br |   commit   |   subject
+ ----- | -- | ---------- | -------------------------------------------""".format(
+         left = left,
+         right = right))
+
+    branch_marker = { '<': '<-', '>': '->', '=' : '==' }
+
+    try:
+        for prnum, _, branch, commit, subject in commits:
+            print(' #{:>4} | {} | {} | {} '.format(
+                prnum, branch_marker[branch], commit, subject
+            ))
+    except subprocess.CalledProcessError as e:
+        print(e, file=sys.stderr)


### PR DESCRIPTION
This tool is a slightly improved and renamed version of the script in  https://github.com/openssl/openssl/issues/7397.

```
$ cherry-checker --help
usage: cherry-checker [-h] [-a] [-s] [-r]

Shows the commits in 'master...OpenSSL_1_1_1-stable' which are eligible for
cherry-picking. A commit is considered cherry-picked, if there is another
commit on the "other side" which introduces an equivalent patch. For details,
see the documentation of the '--cherry-mark' option in the git-log(1) manpage.

optional arguments:
  -h, --help    show this help message and exit
  -a, --all     Show all commits, also those which have been cherry-picked.
  -s, --sort    Sort commits w.r.t. pull request number and author date.
  -r, --remote  Compare the remote branches instead of the local ones.
```


### Improvements

There are some improvements compared to the first version in  https://github.com/openssl/openssl/issues/7397: The output is now symmetric, it shows commits from the symmetric difference of both branches which are not cherry-picked to the "other branch". To which branch a commit belongs is indicated by direction markers (`<-`, `->`). Commits which have an equivalent on the "other branch" are considered cherry-picked and are suppressed from the output, unless `--all`is specified (see below).

One advantage of this change is that now commits which were cherry-picked, but not cleanly, can now be detected in the output. See for example pull request `#7378`:

``` 
 #7378 | -> | 7f0e220f4d | crypto/rand: fix some style nit's 
 #7378 | <- | c2e33a05b1 | crypto/rand: fix some style nit's 
```


The option `--all` shows all commits from the symmetric difference, including commits with an equivalent counterpart (both sides appear and are marked with `==`). The `--all` option can conveniently be combined with the `--sort` option, which is useful if some time has elapsed between the merging and the cherry-picking of a a pull request. See for example pull request `#7363`:

```
 #7363 | == | c033101db3 | Safer memory cleanup in (crypto/rsa/rsa_lib.c) 
 #7363 | == | 3924d69965 | Safer memory cleanup in (crypto/rsa/rsa_lib.c) 
```




### Sample output

As already mentioned in the issue, the output is not only optimized for the terminal, it also has the nice property that it's a valid GitHub Markdown Table. You can copy & paste it into an issue, switch to preview mode and then jump to the pull requests and the commits for inspection.

```
~/src/openssl$ cherry-checker 
These cherries are hanging on the git-tree:

  <-  master
  ->  OpenSSL_1_1_1-stable
  ==  both

 prnum | br |   commit   |   subject
 ----- | -- | ---------- | -------------------------------------------
 #7378 | -> | 7f0e220f4d | crypto/rand: fix some style nit's 
 #7378 | <- | c2e33a05b1 | crypto/rand: fix some style nit's 
 #7365 | <- | 5f9f67b9d4 | Fix no-engine 
 #7376 | <- | a5fcce6b95 | mkdef: bsd-gcc uses solaris symbol version scripts 
 #7360 | <- | 5b639d4cb3 | Indentation fixes. 
 #7329 | <- | b770a80f6d | Remove useless check. Hash can be longer than EC group degree and it w... 
 #7347 | <- | 36d3acb91d | util/mkdef.pl: for VMS, allow generation of case insensitive symbol ve... 
 #7347 | <- | 05a72c28b2 | Configure: use correct variable to infer the .ld file location 
 #7347 | <- | 66a24ab868 | Add build file support for generic symbol exports with DSOs 
 #7347 | <- | ed57d89bd1 | Change the build of engines to use ordinal files for symbol export 
 #7347 | <- | 97624638b0 | util/mkdef.pl: Produce version scripts from unversioned symbols 
```