### PR TITLE
cherry-checker: add a 'fixes' column

### DIFF
--- a/review-tools/cherry-checker
+++ b/review-tools/cherry-checker
@@ -76,12 +76,15 @@ def pick_cherries(left, right, all = False):
         left + "..." + right, "--pretty=%at;%m;%h;%s"
     ]
 
-    regex   = re.compile("|".join([
+    prnum_regex   = re.compile("|".join([
         # The standard pull request annotation
         "\(Merged from https://github.com/openssl/openssl/pull/([0-9]+)\)",
         # @kroeck's special pull request annotation ;-)
         "GH: #([0-9]+)"
     ]))
+
+    fixes_regex   = re.compile(
+        "Fixes[:]?\s+(#|https://github.com/openssl/openssl/pull/)([0-9]+)")
 
     for line in subprocess.check_output(git_command).decode().splitlines():
 
@@ -99,7 +102,7 @@ def pick_cherries(left, right, all = False):
             ["git", "show", "--no-patch", commit]
         ).decode()
 
-        match = regex.search(message)
+        match = prnum_regex.search(message)
         if match:
             if match.group(1):
                 prnum = match.group(1)
@@ -108,7 +111,13 @@ def pick_cherries(left, right, all = False):
         else:
             prnum = "????"
 
-        yield prnum, timestamp, branch, commit, subject
+        match = fixes_regex.search(message)
+        if match:
+            fixes = "#" + match.group(2)
+        else:
+            fixes = ""
+
+        yield prnum, fixes, timestamp, branch, commit, subject
 
 
 
@@ -136,17 +145,17 @@ if __name__ == '__main__':
   ->  {right}
   ==  both
 
- prnum | br |   commit   |   subject
- ----- | -- | ---------- | -------------------------------------------""".format(
+ prnum | fixes | br |   commit   |   subject
+ ----- | ----- | -- | ---------- | -------------------------------------------""".format(
          left = left,
          right = right))
 
     branch_marker = { '<': '<-', '>': '->', '=' : '==' }
 
     try:
-        for prnum, _, branch, commit, subject in commits:
-            print(' #{:>4} | {} | {} | {} '.format(
-                prnum, branch_marker[branch], commit, subject
+        for prnum, fixes, _, branch, commit, subject in commits:
+            print(' #{:>4} | {:>5} | {} | {} | {} '.format(
+                prnum, fixes, branch_marker[branch], commit, subject
             ))
     except subprocess.CalledProcessError as e:
         print(e, file=sys.stderr)


### PR DESCRIPTION
Scans the commit messages for 'Fixes' annotations and displays them in an additional column.

Example output:

```
$ cherry-checker  --all --remote

These cherries are hanging on the git-tree:

  <-  origin/master
  ->  origin/OpenSSL_1_1_1-stable
  ==  both

 prnum | fixes | br |   commit   |   subject
 ----- | ----- | -- | ---------- | -------------------------------------------
 #7467 |       | == | 28361a0b82 | RAND: ensure INT32_MAX is defined 
 #7467 |       | == | f81b043ad8 | RAND: ensure INT32_MAX is defined 
 #7352 |       | <- | 97b0b713fb | RSA security bits calculation 
 #7455 | #7449 | == | ece482ff3a | RAND_add(): fix heap corruption in error path 
 #7455 | #7449 | == | 5b4cb385c1 | RAND_add(): fix heap corruption in error path 
 #7451 |       | -> | 132fd512ad | build file templates: have targets for all shared library names 
 #7451 |       | <- | d8cac50b02 | build file templates: have targets for all shared library names 
 #7434 | #7433 | == | 8c6371f9f7 | Don't complain and fail about unknown TLSv1.3 PSK identities in s_serv... 
 #7434 | #7433 | == | 2d015189b9 | Don't complain and fail about unknown TLSv1.3 PSK identities in s_serv... 
 #7375 | #6934 | == | d1bfd8076e | Buffer a ClientHello with a cookie received via DTLSv1_listen 
 #7375 |       | == | 585e691948 | Use the read and write buffers in DTLSv1_listen() 
 #7375 | #6934 | == | 079ef6bd53 | Buffer a ClientHello with a cookie received via DTLSv1_listen 
 #7375 |       | == | 2fc4c77c3f | Use the read and write buffers in DTLSv1_listen() 
 #7431 |       | == | 6c529877cd | Test DTLS cookie generation and verification 
 #7431 | #7428 | == | a6a83827a0 | Fix a DTLS memory leak 
 #7431 |       | == | edcd29efd3 | Test DTLS cookie generation and verification 
 #7431 | #7428 | == | 01666a8c1d | Fix a DTLS memory leak 
 #7294 |       | <- | 9986bfefa4 | sha/asm/keccak1600-armv8.pl: halve the size of hw-assisted subroutine. 
 #7400 |       | == | a66c361a77 | Configurations/15-android.conf: add support for "standalone toolchain"... 
 #7400 |       | == | 03ad7c009e | Configurations/15-android.conf: add support for "standalone toolchain"... 
 #7420 |       | == | fc762e7d5c | arch/async_posix.h: improve portability. 
 #7420 |       | == | 9d71a24ebf | arch/async_posix.h: improve portability. 
 ...
```