### PR TITLE
Tool changes for Mac OS/X.

### DIFF
--- a/OpenSSL-Query/Makefile.PL
+++ b/OpenSSL-Query/Makefile.PL
@@ -35,6 +35,8 @@ requires (
    'URI::Encode'    => 0,
    Moo              => 0,
    Carp             => 0,
+   'LWP::UserAgent' => 0,
+   'LWP::Protocol::https' =>0,
 );
 
 install_as_site;

--- a/OpenSSL-Query/README.md
+++ b/OpenSSL-Query/README.md
@@ -23,6 +23,8 @@ OpenSSL::Query requires these extra modules to run:
 - Class::Method::Modifiers	(debian package libclass-method-modifiers-perl)
 - Moo				(debian package libmoo-perl)
 - URI::Encode			(debian package liburi-encode-perl)
+- LWP::UserAgent
+- LWP::Protocol::https
 
 Any other module OpenSSL::Query depends on should be part of core
 perl.

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/review-tools/gitlabutil
+++ b/review-tools/gitlabutil
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use HTTP::Tiny;
 use JSON::PP;


### PR DESCRIPTION
Perl ends up with a different path when installed using _brew_.  The system perl
seems to have broken _cpan_ somehow.

Some additional packages need to be installed.

PATH also needs to be set so it can find the _plackup_ executable.