### PR TITLE
release-tools/do-copyright-year spinner and fixups

### DIFF
--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -29,12 +29,29 @@ EOF
 
 NYD=`date +%Y-01-01`
 echo Updating copryight
-git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD \
-	| while read STATUS FILE ; do
-    if [ "$STATUS" = 'D' ]; then continue; fi
-    sed -E -f /tmp/sed$$ -i "$FILE"
-    git add "$FILE"
-done
+git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
+    (
+	count=0
+	sp="/-\|"
+	sc=0
+	spin() {
+	    printf "\r${sp:sc++:1} %s" "$@"
+	    ((sc==${#sp})) && sc=0
+	}
+	endspin() {
+	    printf "\r%s\n" "$@"
+	}
+
+	while read STATUS FILE ; do
+	    if [ "$STATUS" = 'D' ]; then continue; fi
+	    (( count++ ))
+	    spin $count
+	    sed -E -f /tmp/sed$$ -i "$FILE"
+	    git add "$FILE"
+	done
+	endspin "Files considered: $count"
+    )
+echo Files changed: $(git status --porcelain | grep '^ *M' | wc -l)
 echo Committing change locally.
 git commit -m 'Update copyright year'
 rm -f $ss

--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -44,6 +44,7 @@ git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
 	}
 
 	while read STATUS FILE ; do
+	    if [ -d "$FILE" ]; then continue; fi
 	    (( count++ ))
 	    spin $count
 	    sed -E -f /tmp/sed$$ -i "$FILE"

--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -30,6 +30,7 @@ EOF
 NYD=`date +%Y-01-01`
 echo Updating copryight
 git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
+    grep -v '^ *D' | \
     (
 	count=0
 	sp="/-\|"
@@ -43,7 +44,6 @@ git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
 	}
 
 	while read STATUS FILE ; do
-	    if [ "$STATUS" = 'D' ]; then continue; fi
 	    (( count++ ))
 	    spin $count
 	    sed -E -f /tmp/sed$$ -i "$FILE"


### PR DESCRIPTION
Most of all, this adds a spinner.  The experience with the OpenSSL 1.1.1 series, which includes a *lot* of changes since the beginning of this year, is that it can take quite some time to go through all of them.  Some visual feedback is something to appreciate.