### PR TITLE
Add new ghlink tool

### DIFF
--- a/review-tools/ghlink
+++ b/review-tools/ghlink
@@ -1,0 +1,280 @@
+#!/usr/bin/env perl
+#
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+#
+# ghlink - convert repository locations into GitHub links
+#
+
+use warnings;
+use strict;
+
+use File::Basename;
+use Getopt::Long;
+use Pod::Usage;
+
+my $progname=basename($0);
+
+my $repo = "https://github.com/openssl/openssl";
+my $tree = "$repo/tree";
+my $blob = "$repo/blob";
+
+my $regex_name = "[[:alpha:]._-]+[[:alnum:]._-]*";
+my $regex_revision = "[[:alnum:]._-]+";
+my $regex_path = "(?:${regex_name}/)*${regex_name}";
+my $regex_lineno = "[0-9]+";
+
+my $style = 'default';
+
+my $replace = \&link;
+
+my $markdown = 0;
+my $permanent = 0;
+my $list = 0;
+my $help = 0;
+my $man = 0;
+
+GetOptions('markdown|m'        => \$markdown,
+           'permanent|p'       => \$permanent,
+           'list|l'            => \$list,
+           'help|h'            => \$help,
+           'man'               => \$man)
+    or die "Errors in command line arguments\n";
+
+if ($help) {
+    pod2usage(-exitval => 0,
+              -verbose => 1);
+}
+if ($man) {
+    pod2usage(-exitval => 0,
+              -verbose => 2);
+}
+
+if ($markdown) {
+    $replace = \&markdown
+}
+
+
+my $remotes = `git remote -v`;
+if ($? != 0 or $remotes !~ "openssl\.git") {
+    die "Current directory does not belong to an OpenSSL git repository";
+}
+
+my $curr_branch = `git rev-parse --abbrev-ref HEAD`;
+chomp $curr_branch;
+
+my $prefix = `git rev-parse --show-prefix`;
+chomp $prefix;
+
+
+# some results are cached for efficiency reasons
+
+my %commits;
+my %urls;
+
+sub check_url {
+    my ($match, $revision, $path, $lineno) = @_;
+
+    if (!defined($revision)) {
+        $revision = $curr_branch;
+    }
+
+    my $abbrev_commit = ($permanent) ? "" : "--abbrev-commit";
+
+    if (!defined($commits{$revision})) {
+        my $c = `git rev-list $abbrev_commit -1 $revision -- 2>/dev/null`;
+        chomp $c;
+
+        if ($? != 0) {
+            $commits{$revision} = "";
+        } elsif ($permanent) {
+            # always use the commit id if --permanent was specified
+            $commits{$revision} = $c;
+        } else {
+            # if a branch name was specified, use if it exists remotely
+            # otherwise, use the commit id
+            `git ls-remote --exit-code $repo --heads refs/heads/$revision`;
+            $commits{$revision} = ($? == 0) ? $revision : $c;
+        }
+    }
+
+    $revision = $commits{$revision};
+
+    if (!$revision) {
+        return "";
+    }
+
+    my $gitpath = "$revision:$prefix$path";
+
+    if (!defined($urls{$gitpath})) {
+        # create urls only for objects in the local repository
+        `git rev-parse $gitpath 2>/dev/null`;
+        if ($? != 0) {
+            $urls{$gitpath} = "";
+        } else {
+            $urls{$gitpath} = "$blob/$revision/$prefix$path";
+        }
+    }
+
+    my $url = $urls{$gitpath};
+
+    if (!$url) {
+        return "";
+    }
+
+    return defined($lineno) ? "$url#L$lineno" : "$url";
+}
+
+sub link {
+    my ($match, $revision, $path, $lineno) = @_;
+
+    my $url = check_url($match, $revision, $path, $lineno);
+
+    if (!$url) {
+        return $match;
+    }
+
+    return $url;
+}
+
+sub markdown {
+    my ($match, $revision, $path, $lineno) = @_;
+
+    my $url = check_url($match, $revision, $path, $lineno);
+
+    if (!$url) {
+        return $match;
+    }
+
+    return "[$match]($url)";
+}
+
+if ($list) {
+    # list mode: print github links for all matched locations (and discard the rest)
+    while (<>) {
+        while (/(?:(${regex_revision}):)?(${regex_path}):(${regex_lineno})?:?/g) {
+            my $found = $replace->($&,$1,$2,$3);
+            if ($found ne $&) {
+                print ("$found\n");
+            }
+        }
+    }
+} else {
+    # replace mode: replace all matched locations in the text with github links
+    while (<>) {
+        s/(?:(${regex_revision}):)?(${regex_path}):(${regex_lineno})?:?/$replace->($&,$1,$2,$3)." "/eg;
+        print;
+    }
+}
+
+
+__END__
+
+=head1 NAME
+
+ghlink - convert repository locations into GitHub links
+
+=head1 SYNOPSIS
+
+  ghlink [<option>...] [<file>...]
+
+Concatenate the given file(s) to standard output, converting repository
+locations into GitHub links. If no file is given, read from stdin.
+
+
+=head1 DESCRIPTION
+
+The most common usage of ghlink is to add it as an output filter for commands which
+produce output referring to locations in the repository. A location can be of roughly
+the following form:
+
+    [<branch-or-commit>:]<path>:[<lineno>[:]]
+
+Examples of such commands are git-grep or find:
+
+  git grep [-n] [-e] <expression>  ...  |  ghlink [<option>...]
+
+  find -name <pattern> ...  |  ghlink [<option>...]
+
+Alternatively, the output of the commands can be redirected into files which then
+can be specified as commandline arguments for ghlink.
+
+  ghlink <file>...
+
+The ghlink filter recognizes the locations and converts them into links to the
+OpenSSL GitHub repository, depending on the given options. It tries hard to provide
+only valid locations. For that reason, ghlink requires to be run from within the
+working copy. It is allowed to run ghlink from subdirectories, because it takes
+its relative position into account. Branch names in the output (like from git-grep)
+are recognized, and if they are missing, the current branch is assumed. When creating
+the link, ghlink attempts to preserve the branch name, provided the branch exists on
+the remote repository too (e.g. master, OpenSSL_x_y_z-stable). If the branch does not
+exist remotely (or if the --permanent option was specified), the branch is resolved
+locally to a commit-id.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--help>
+
+Print a brief help message and exit.
+
+=item B<--man>
+
+Print the manual page and exit.
+
+=item B<--markdown> | B<-m>
+
+Convert the locations to links in markdown syntax, with the location in square brackets,
+followed by the link in parentheses.
+
+=item B<--permanent> | B<-p>
+
+Always resolve branches to (unabbreviated) commit-ids for printing the link.
+
+=item B<--list> | B<-l>
+
+List only the links of all locations found, and omit the resto of th text. This option
+is useful together with the --permanent option to create GitHub permalinks, see EXAMPLES
+section below.
+
+=back
+
+=head1 EXAMPLES
+
+=over 4
+
+=item B<~/src/openssl$ git grep -n expression | ghlink>
+
+Search for an expression locally in the repository and browse the results directly
+on GitHub by clicking on the URLs using <ctrl>-<left-mouse> (or whatever key binding
+the terminal supports).
+
+=item B<~/src/openssl$ git grep -n expression | ghlink --markdown  [--permanent]>
+
+Produces output optimized for posting the result on GitHub as an issue or
+pull request comment. The locations show up as markdown links in the
+original grep output format.
+
+=item B<~/src/openssl$ git grep -n expression | ghlink --permanent --list>
+
+Produces output optimized for posting the result on GitHub as an issue or
+pull request comment. The locations show up as permalink text boxes, which
+is the reason why --list was output only the permalinks and omit the text.
+
+=item B<~/src/openssl$ ghlink --markdown {gdb.log,asan.log,tsan.log,...}>
+
+The ghlink tool also works nicely with call stacks produced by gdb, AddressSanitizer,
+or ThreadSanitizer and facilitates viewing the stack frames directly in the source.
+It can either be applied directly as output filter or subsequently on the saved
+log files.
+
+=back
+
+=cut

--- a/review-tools/ghlink
+++ b/review-tools/ghlink
@@ -154,10 +154,12 @@ sub markdown {
     return "[$match]($url)";
 }
 
+my $regex = qr/(?:(${regex_revision}):)?(${regex_path}):(${regex_lineno})?:?/;
+
 if ($list) {
     # list mode: print github links for all matched locations (and discard the rest)
     while (<>) {
-        while (/(?:(${regex_revision}):)?(${regex_path}):(${regex_lineno})?:?/g) {
+        while (/$regex/g) {
             my $found = $replace->($&,$1,$2,$3);
             if ($found ne $&) {
                 print ("$found\n");
@@ -167,7 +169,7 @@ if ($list) {
 } else {
     # replace mode: replace all matched locations in the text with github links
     while (<>) {
-        s/(?:(${regex_revision}):)?(${regex_path}):(${regex_lineno})?:?/$replace->($&,$1,$2,$3)." "/eg;
+        s/$regex/$replace->($&,$1,$2,$3)." "/eg;
         print;
     }
 }


### PR DESCRIPTION
## The Story

Very often, when posting a reply to an issue or a pull request, It happens that I need to look up some stuff in my local repository:

```make
~/src/openssl$ git grep -nw stuff
.gitignore:69:# Fuzz stuff.
...
config:344:# Do the Apollo stuff first. Here, we just simply assume
...
crypto/aes/asm/vpaes-armv8.pl:94://  Decryption stuff
...
crypto/asn1/tasn_enc.c:316:        /* And the stuff itself */
...
crypto/bio/b_dump.c:11: * Stolen from tjh's ssl/ssl_trc.c stuff.
...
```

Grepping the stuff is the easy part, but after that it gets tedious, because I have to fire up my browser and navigate manually through the GitHub repository in order to retrieve the same locations once more. In these moments I dream of a tool that could convert those grep hits into URLs, which would take me off to GitHub via  `<ctrl>-<left-mouse-click>` :rocket:


```make
~/src/openssl$ git grep -nw stuff
https://github.com/openssl/openssl/blob/master/.gitignore#L69 # Fuzz stuff.
...
https://github.com/openssl/openssl/blob/master/config#L344 # Do the Apollo stuff first. Here, we just simply assume
...
https://github.com/openssl/openssl/blob/master/crypto/aes/asm/vpaes-armv8.pl#L94 //  Decryption stuff
...
https://github.com/openssl/openssl/blob/master/crypto/asn1/tasn_enc.c#L316         /* And the stuff itself */
...
https://github.com/openssl/openssl/blob/master/crypto/bio/b_dump.c#L11  * Stolen from tjh's ssl/ssl_trc.c stuff.
...
```

### Dreaming further...

...I whish I could also post these links as markdown links...

> [.gitignore:69:](https://github.com/openssl/openssl/blob/master/.gitignore#L69) # Fuzz stuff.
> [CHANGES:11033:](https://github.com/openssl/openssl/blob/master/CHANGES#L11033)      the new code. Add documentation for this stuff.
> [config:344:](https://github.com/openssl/openssl/blob/master/config#L344) # Do the Apollo stuff first. Here, we just simply assume
> [crypto/aes/asm/vpaes-armv8.pl:94:](https://github.com/openssl/openssl/blob/master/crypto/aes/asm/vpaes-armv8.pl#L94) //  Decryption stuff
> [crypto/asn1/a_int.c:417:](https://github.com/openssl/openssl/blob/master/crypto/asn1/a_int.c#L417)      * We must OPENSSL_malloc stuff, even for 0 bytes otherwise it signifies
> [crypto/asn1/tasn_enc.c:316:](https://github.com/openssl/openssl/blob/master/crypto/asn1/tasn_enc.c#L316)         /* And the stuff itself */
> [crypto/bio/b_dump.c:11:](https://github.com/openssl/openssl/blob/master/crypto/bio/b_dump.c#L11)  * Stolen from @t-j-h's ssl/ssl_trc.c stuff.

... or even as these fancy little GitHub permalink boxes:

> https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/.gitignore#L69
> https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/config#L344
> https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/aes/asm/vpaes-armv8.pl#L94
> https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/asn1/tasn_enc.c#L316
> https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/bio/b_dump.c#L11

_(Note: unfortunately, GitHub spoiled my fun here because it does not display permalink boxes for cross-repository links. You would have to paste those links into some openssl/openssl issue or pull request to see the boxes.)_

## Introducing ghlink

For all of you who shared my dreams, it's time to wake up, because here comes my solution: It is a little perl script called `ghlink` which can be used (among others) as an output filter for commands like git-grep. To get its manual page, simply run `ghlink --man`.

```
NAME
    ghlink - convert repository locations into GitHub links

SYNOPSIS
      ghlink <option>... <file>...

    Concatenate the given file(s) to standard output, converting repository
    locations into GitHub links. If no file is given, read from stdin.

DESCRIPTION
    The most common usage of ghlink is to add it as an output filter for
    commands which produce output referring to locations in the repository.
    A location can be of roughly the following form:

        [<branch-or-revision>:]<path>:[<lineno>[:]]

    Examples of such commands are git-grep or find:

      git grep [-n] [-e] <expression>  ...  |  ghlink [<option>...]

      find -name <pattern> ...  |  ghlink [<option>...]

    Alternatively, the output of the commands can be redirected into files
    which then can be specified as commandline arguments for ghlink.

      ghlink <file>...

    The ghlink filter recognizes the locations and converts them into links
    to the OpenSSL GitHub repository, depending on the given options. It
    tries hard to provide only valid locations. For that reason, ghlink
    requires to be run from within the working copy. It is allowed to run
    ghlink from subdirectories, because it takes its relative position into
    account. Branch names in the output (like from git-grep) are recognized,
    and if they are missing, the current branch is assumed. When creating
    the link, ghlink attempts to preserve the branch name, provided the
    branch exists on the remote repository too (e.g. master,
    OpenSSL_x_y_z-stable). If the branch does not exist remotely (or if the
    --permanent option was specified), the branch is resolved locally to a
    commit-id.

OPTIONS
    --help
        Print a brief help message and exit.

    --man
        Print the manual page and exit.

    --markdown | -m
        Convert the locations to links in markdown syntax, with the location
        in square brackets, followed by the link in parentheses.

    --permanent | -p
        Always resolve branches to (unabbreviated) commit-ids for printing
        the link.

    --list | -l
        List only the links of all locations found, and omit the resto of th
        text. This option is useful together with the --permanent option to
        create GitHub permalinks, see EXAMPLES section below.

EXAMPLES
    ~/src/openssl$ git grep -nw stuff | ghlink
        Search for stuff locally in the repository and browse the results
        directly on GitHub by clicking on the URLs using <ctrl>-<left-mouse>
        (or whatever key binding the terminal supports).

    ~/src/openssl$ git grep -n expression | ghlink --markdown [--permanent]
        Produces output optimized for posting the result on GitHub as an
        issue or pull request comment. The locations show up as links

    ~/src/openssl$ git grep -n expression | ghlink --permanent --list
        Produces output optimized for posting the result on GitHub as an
        issue or pull request comment. The locations show up as permalink
        text boxes, which is the reason why --list was output only the
        permalinks and omit the text.

    ~/src/openssl$ ghlink --markdown {gdb.log,asan.log,...}
        ghlink also works nicely with call stacks produced by gdb or the
        address sanitizer and facilitates viewing the stack frames directly
        in the source.

```


## Examples

This is how the three examples in the story above were created

### Create Shell Links

**~/src/openssl$ git grep -nw stuff | ghlink**
```make
https://github.com/openssl/openssl/blob/master/.gitignore#L69 # Fuzz stuff.
https://github.com/openssl/openssl/blob/master/config#L344 # Do the Apollo stuff first. Here, we just simply assume
https://github.com/openssl/openssl/blob/master/crypto/aes/asm/vpaes-armv8.pl#L94 //  Decryption stuff
https://github.com/openssl/openssl/blob/master/crypto/asn1/tasn_enc.c#L316         /* And the stuff itself */
https://github.com/openssl/openssl/blob/master/crypto/bio/b_dump.c#L11  * Stolen from tjh's ssl/ssl_trc.c stuff.
```

### Create Markdown Links

**~/src/openssl$ git grep -nw stuff | ghlink --markdown**
```make
[.gitignore:69:](https://github.com/openssl/openssl/blob/master/.gitignore#L69) # Fuzz stuff.
[config:344:](https://github.com/openssl/openssl/blob/master/config#L344) # Do the Apollo stuff first. Here, we just simply assume
[crypto/aes/asm/vpaes-armv8.pl:94:](https://github.com/openssl/openssl/blob/master/crypto/aes/asm/vpaes-armv8.pl#L94) //  Decryption stuff
[crypto/asn1/tasn_enc.c:316:](https://github.com/openssl/openssl/blob/master/crypto/asn1/tasn_enc.c#L316)         /* And the stuff itself */
[crypto/bio/b_dump.c:11:](https://github.com/openssl/openssl/blob/master/crypto/bio/b_dump.c#L11)  * Stolen from tjh's ssl/ssl_trc.c stuff.
```

_(Well, I have to admit that I couldn't resist to cheat a little with the link to @t-j-h :grin:)_

### Create GitHub PermaLinks

**~/src/openssl$ git grep -nw stuff | ghlink --list --permanent**
```make
https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/.gitignore#L69
https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/config#L344
https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/aes/asm/vpaes-armv8.pl#L94
https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/asn1/tasn_enc.c#L316
https://github.com/openssl/openssl/blob/5acb2be58b693f504c76eb07f5b9133b02895f3b/crypto/bio/b_dump.c#L11
```

## More Examples

### Pimp up GDB and ThreadSanitizer Callstacks

The following example was taken from @bernd-edlinger's https://github.com/openssl/openssl/pull/9513#issuecomment-520123111 and converted using the --markdown option on branch pr-9513 ->  https://github.com/openssl/openssl/commit/a0852950c8f850db841d8f723d3cae83454f7ef7:

WARNING:  ThreadSanitizer:  data race (pid=13157)
  Read of size 4 at 0x00000072eff4 by thread T1: 
    #0 openssl_ctx_get_data [crypto/context.c:186](https://github.com/openssl/openssl/blob/a0852950c8/crypto/context.c#L186)  (a.out+0x4c96e6)
    #1 drbg_get_global [crypto/rand/drbg_lib.c:245](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/drbg_lib.c#L245)  (a.out+0x41fd98)
    #2 OPENSSL_CTX_get0_public_drbg [crypto/rand/drbg_lib.c:1334](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/drbg_lib.c#L1334)  (a.out+0x41fd98)
    #3 rand_bytes_ex [crypto/rand/rand_lib.c:840](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/rand_lib.c#L840)  (a.out+0x408a79)
    #4 RAND_bytes [crypto/rand/rand_lib.c:850](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/rand_lib.c#L850)  (a.out+0x408a79)
    #5 t1 /home/ed/OPC/openssl/test.c:10  (a.out+0x406556)

  Previous write of size 4 at 0x00000072eff4 by main thread: 
    #0 openssl_ctx_init_index [crypto/context.c:173](https://github.com/openssl/openssl/blob/a0852950c8/crypto/context.c#L173)  (a.out+0x4c97c7)
    #1 openssl_ctx_get_data [crypto/context.c:187](https://github.com/openssl/openssl/blob/a0852950c8/crypto/context.c#L187)  (a.out+0x4c97c7)
    #2 drbg_get_global [crypto/rand/drbg_lib.c:245](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/drbg_lib.c#L245)  (a.out+0x41fd98)
    #3 OPENSSL_CTX_get0_public_drbg [crypto/rand/drbg_lib.c:1334](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/drbg_lib.c#L1334)  (a.out+0x41fd98)
    #4 rand_bytes_ex [crypto/rand/rand_lib.c:840](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/rand_lib.c#L840)  (a.out+0x408a79)
    #5 RAND_bytes [crypto/rand/rand_lib.c:850](https://github.com/openssl/openssl/blob/a0852950c8/crypto/rand/rand_lib.c#L850)  (a.out+0x408a79)
    #6 main /home/ed/OPC/openssl/test.c:22  (a.out+0x40412e)

  Location is global 'default_context_int' of size 240 at 0x00000072ef40 (a.out+0x00000072eff4)

  Thread T1 (tid=13159, running) created by main thread at: 
    #0 pthread_create ../../../../gcc-trunk/libsanitizer/tsan/tsan_interceptors.cc:964  (libtsan.so.0+0x304eb)
    #1 main /home/ed/OPC/openssl/test.c:19  (a.out+0x404111)

SUMMARY:  ThreadSanitizer:  data race [crypto/context.c:186](https://github.com/openssl/openssl/blob/a0852950c8/crypto/context.c#L186)  in openssl_ctx_get_data
