### PR TITLE
cherry-checker: fix: don't choke on semicolons in the commit message title

### DIFF
--- a/review-tools/cherry-checker
+++ b/review-tools/cherry-checker
@@ -88,7 +88,7 @@ def pick_cherries(left, right, all = False):
 
     for line in subprocess.check_output(git_command).decode().splitlines():
 
-        timestamp, branch, commit, subject = line.split(";")
+        timestamp, branch, commit, subject = line.split(";", maxsplit=3)
 
         if branch == '=' and not all:
             continue


### PR DESCRIPTION
The semicolon is used as separator for the git output, so make sure
to stop the line.split() after the third separator, otherwise the
subject line might get split further.

(see openssl/openssl@bd01733fdd Fix comment; unchecked->checked)