### PR TITLE
Improve addrev and ghmerge tools and their README

### DIFF
--- a/review-tools/README
+++ b/review-tools/README
@@ -47,10 +47,10 @@ The transfer may take many seconds, in particular with the '--list' option.
 
 Examples:
 
-    addrev steve
-    addrev -2 steve
-    addrev -2 steve @richsalz
-    addrev -2 --reviewer=steve --reviewer=rsalz@openssl.org
+    addrev --prnum=1234 steve
+    addrev 1234 -2 steve
+    addrev 1234 -2 steve @richsalz
+    addrev 1234 -2 --reviewer=steve --reviewer=rsalz@openssl.org
 
 gitlabutil
 ----------

--- a/review-tools/README
+++ b/review-tools/README
@@ -117,21 +117,18 @@ The environment variables 'https_proxy' and 'no_proxy' can be used.
 
 Example usage patterns:
         ghmerge <prnum> <reviewers>...
-        ghmerge --tools --nomerge <prnum> <reviewer>...
+        ghmerge --tools --squash <prnum> <reviewer>...
 
 Available options are:
 
---nomerge         Use 'git rebase -i --autosquash'.
-                  This is the default.
---autosquash      An alias to '--nomerge'.
---merge           Use 'git merge --no-commit --squash'.
---squash          An alias to '--merge'.
+--squash          Use non-interactive 'git merge --ff-only --squash'.
+                  The default is interactive 'git rebase -i --autosquash'.
 --nobuild         Do not use 'opensslbuild'.
                   Else it is invoked with $CC defaulting to "ccache gcc".
 --tools           Select the 'tools' repository rather than 'openssl'.
-                  This implies '--merge' and '--nobuild'.
+                  This implies '--nobuild'.
 --web             Select the 'web' repository rather than 'openssl'.
-                  This implies '--merge' and '--nobuild'.
+                  This implies '--nobuild'.
 --trivial         Pass '--trivial' to the invocation of 'addrev'.
 
 The <prnum> is the GitHub PR number.  The rest of the args are the names

--- a/review-tools/README
+++ b/review-tools/README
@@ -121,17 +121,19 @@ Example usage patterns:
         ghmerge <prnum> <reviewers>...
         ghmerge --tools --squash <prnum> <reviewer>...
 
+The default commit post-processing operaton is 'git rebase -i --autosquash'.
+
 Available options are:
 
---squash          Use non-interactive 'git merge --ff-only --squash'.
-                  The default is interactive 'git rebase -i --autosquash'.
---nobuild         Do not use 'opensslbuild'.
-                  Else it is invoked with $CC defaulting to "ccache gcc".
---tools           Select the 'tools' repository rather than 'openssl'.
-                  This implies '--nobuild'.
---web             Select the 'web' repository rather than 'openssl'.
-                  This implies '--nobuild'.
---trivial         Pass '--trivial' to the invocation of 'addrev'.
+--noautosquash  Use default interactive post-processing but without '--autosquash'.
+--squash        Use non-interactive post-processing 'git merge --ff-only --squash'.
+--nobuild       Do not use 'opensslbuild'.
+                Else it is invoked with $CC defaulting to "ccache gcc".
+--tools         Select the 'tools' repository rather than 'openssl'.
+                This implies '--nobuild'.
+--web           Select the 'web' repository rather than 'openssl'.
+                This implies '--nobuild'.
+--trivial       Pass '--trivial' to the invocation of 'addrev'.
 
 The <prnum> is the GitHub PR number.  The rest of the args are the names
 of the reviewers. All this info will be passed to addrev; see above.

--- a/review-tools/README
+++ b/review-tools/README
@@ -101,16 +101,37 @@ Checkout branch for query 145:
 ghmerge
 -------
 
-ghmerge merges (reviewed and approved!) GitHub pull requests
+ghmerge calls addrev and pushes (reviewed and approved!) GitHub pull requests.
+It includes several safety precautions and questions such as showing the diff,
+showing the resulting commit messages, and (by default) rebuilding everything.
 
-It works on the current branch, which should be master or one of the stable
-releases.
+It works on the current branch, which should be 'master' or one of the stable
+releases. For the branch to be merged a suitable remote must be available.
 
-Usage:
-        ghmerge ### reviewer...
+The tool accesses external databases via HTTPS (e.g., on api.github.com).
+The environment variables 'https_proxy' and 'no_proxy' can be used.
 
-The ### is the GitHub MR number.  The rest of the args are the names of
-the reviewers (passed to addrev; see above).
+Example usage patterns:
+        ghmerge <prnum> <reviewers>...
+        ghmerge --tools --nomerge <prnum> <reviewer>...
+
+Available options are:
+
+--nomerge         Use 'git rebase -i --autosquash'.
+                  This is the default.
+--autosquash      An alias to '--nomerge'.
+--merge           Use 'git merge --no-commit --squash'.
+--squash          An alias to '--merge'.
+--nobuild         Do not use 'opensslbuild'.
+                  Else it is invoked with $CC defaulting to "ccache gcc".
+--tools           Select the 'tools' repository rather than 'openssl'.
+                  This implies '--merge' and '--nobuild'.
+--web             Select the 'web' repository rather than 'openssl'.
+                  This implies '--merge' and '--nobuild'.
+--trivial         Pass '--trivial' to the invocation of 'addrev'.
+
+The <prnum> is the GitHub PR number.  The rest of the args are the names
+of the reviewers. All this info will be passed to addrev; see above.
 
 
 pick-to-branch

--- a/review-tools/README
+++ b/review-tools/README
@@ -113,7 +113,7 @@ It includes several safety precautions and questions such as showing the diff,
 showing the resulting commit messages, and (by default) rebuilding everything.
 
 It works on the current branch, which should be 'master' or one of the stable
-releases. For pushing the remote 'origin' is used by default.
+releases. The default remote is the first one matching 'git.openssl.org.*(push)'.
 So typically before calling 'ghmerge' one would have done the following:
 
 	git remote -v
@@ -138,7 +138,7 @@ Available options are:
 --nobuild       Do not use 'opensslbuild'.
                 Else it is invoked with $CC defaulting to "ccache gcc".
 --remote        Select the git remote of the branch to pull from and push to.
-                Default is 'origin'.
+                Default is the first remote matching 'git.openssl.org.*(push)'.
 --tools         Select the 'tools' repository rather than 'openssl'.
                 This implies '--nobuild'.
 --web           Select the 'web' repository rather than 'openssl'.

--- a/review-tools/README
+++ b/review-tools/README
@@ -11,7 +11,10 @@ the QueryApp libraries as well.
 Environment
 ===========
 
-Some of the scripts use the information REST API on https://api.openssl.org.
+Some of the scripts use the information REST API on https://api.openssl.org
+or on https://api.github.com.
+The environment variables 'https_proxy' and 'no_proxy' can be used.
+
 If you have direct access to the databases and want to use that instead, set
 the environment variable OMC to the directory where they are located.
 
@@ -38,8 +41,7 @@ IDs prefixed with a @, or known email addresses if given with --reviewer.
 
 Run 'addrev --list' to ge a list of known reviewer names.
 
-The tool accesses databases on www.openssl.org via HTTPS.
-The environment variables 'https_proxy' and 'no_proxy' can be used.
+The tool accesses databases on api.openssl.org via HTTPS.
 The transfer may take many seconds, in particular with the '--list' option.
 
 Examples:
@@ -112,7 +114,7 @@ showing the resulting commit messages, and (by default) rebuilding everything.
 It works on the current branch, which should be 'master' or one of the stable
 releases. For the branch to be merged a suitable remote must be available.
 
-The tool accesses external databases via HTTPS (e.g., on api.github.com).
+The tool accesses external databases on api.github.com via HTTPS.
 The environment variables 'https_proxy' and 'no_proxy' can be used.
 
 Example usage patterns:

--- a/review-tools/README
+++ b/review-tools/README
@@ -12,7 +12,7 @@ Environment
 ===========
 
 Some of the scripts use the information REST API on https://api.openssl.org
-or on https://api.github.com.
+while ghmerge also uses https://api.github.com.
 The environment variables 'https_proxy' and 'no_proxy' can be used.
 
 If you have direct access to the databases and want to use that instead, set
@@ -41,7 +41,8 @@ IDs prefixed with a @, or known email addresses if given with --reviewer.
 
 Run 'addrev --list' to ge a list of known reviewer names.
 
-The tool accesses databases on api.openssl.org via HTTPS.
+The tool accesses databases on api.openssl.org.
+The environment variables 'https_proxy' and 'no_proxy' can be used.
 The transfer may take many seconds, in particular with the '--list' option.
 
 Examples:
@@ -114,7 +115,7 @@ showing the resulting commit messages, and (by default) rebuilding everything.
 It works on the current branch, which should be 'master' or one of the stable
 releases. For the branch to be merged a suitable remote must be available.
 
-The tool accesses external databases on api.github.com via HTTPS.
+The tool accesses external databases on api.openssl.org and api.github.com.
 The environment variables 'https_proxy' and 'no_proxy' can be used.
 
 Example usage patterns:

--- a/review-tools/README
+++ b/review-tools/README
@@ -113,7 +113,14 @@ It includes several safety precautions and questions such as showing the diff,
 showing the resulting commit messages, and (by default) rebuilding everything.
 
 It works on the current branch, which should be 'master' or one of the stable
-releases. For the branch to be merged a suitable remote must be available.
+releases. For pushing the remote 'origin' is used by default.
+So typically before calling 'ghmerge' one would have done the following:
+
+	git remote -v
+origin	openssl-git@git.openssl.org:openssl.git (fetch)
+origin	openssl-git@git.openssl.org:openssl.git (push)
+	git fetch origin
+	git checkout master
 
 The tool accesses external databases on api.openssl.org and api.github.com.
 The environment variables 'https_proxy' and 'no_proxy' can be used.
@@ -130,6 +137,8 @@ Available options are:
 --squash        Use non-interactive post-processing 'git merge --ff-only --squash'.
 --nobuild       Do not use 'opensslbuild'.
                 Else it is invoked with $CC defaulting to "ccache gcc".
+--remote        Select the git remote of the branch to pull from and push to.
+                Default is 'origin'.
 --tools         Select the 'tools' repository rather than 'openssl'.
                 This implies '--nobuild'.
 --web           Select the 'web' repository rather than 'openssl'.

--- a/review-tools/README
+++ b/review-tools/README
@@ -38,6 +38,10 @@ IDs prefixed with a @, or known email addresses if given with --reviewer.
 
 Run 'addrev --list' to ge a list of known reviewer names.
 
+The tool accesses databases on www.openssl.org via HTTPS.
+The environment variables 'https_proxy' and 'no_proxy' can be used.
+The transfer may take many seconds, in particular with the '--list' option.
+
 Examples:
 
     addrev steve

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -61,7 +61,7 @@ if ($help) {
     exit(0);
 }
 
-die "Need either --prnum or --nopr flag" unless $haveprnum;
+die "Need either --prnum=NNN or --nopr flag" unless $haveprnum;
 
 if ($useself) {
     if (!defined $my_email) {

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -71,7 +71,9 @@ if ($useself) {
     $args .= "--myemail=$my_email ";
 }
 
-system("git filter-branch -f --tag-name-filter cat --msg-filter \"gitaddrev $args\" $filterargs");
+my $err = "/tmp/addrev$$";
+system("git filter-branch -f --tag-name-filter cat --msg-filter \"gitaddrev $args\" $filterargs || (echo addrev failed; exit 1)");
+die if $?;
 
 sub usage {
     print STDERR <<"EOF";

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -34,8 +34,8 @@ foreach (@ARGV) {
         $my_email = $1;
     } elsif (/^--nopr$/) {
 	$haveprnum = 1;
-    } elsif (/^--prnum=(.+)$/) {
-        $args .= "--prnum=$1 ";
+    } elsif (/^(--prnum=)?(\d+)$/) {
+        $args .= "--prnum=$2 ";
 	$haveprnum = 1;
     } elsif (/^--commit=(.+)$/) {
         $args .= "--commit=$1 ";
@@ -61,7 +61,7 @@ if ($help) {
     exit(0);
 }
 
-die "Need either --prnum=NNN or --nopr flag" unless $haveprnum;
+die "Need either [--prnum=]NNN or --nopr flag" unless $haveprnum;
 
 if ($useself) {
     if (!defined $my_email) {
@@ -90,7 +90,7 @@ option style arguments:
 --myemail=<email>	Set email address.  Defaults to the result from
 			git configuration setting user.email.
 --nopr			Do not requre a PR number.
---prnum=NNN             Add a reference to GitHub pull request NNN
+[--prnum=]NNN           Add a reference to GitHub pull request NNN
 -<n>			Change the last <n> commits.  Defaults to 1.
 
 non-option style arguments can be:

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -100,7 +100,7 @@ git diff $REL
 
 if [ "$INTERACTIVE" == "yes" ] ; then
     # echo -n "Press Enter to interactively rebase --autosquash on $REL: "; read foo
-    git rebase -i --autosquash $REL
+    git rebase -i --autosquash $REL || (git rebase --abort; exit 1)
 fi
 
 addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -5,7 +5,8 @@ set -o errexit
 WHAT=openssl
 BUILD=yes
 TRIVIAL=""
-MERGE="yes"
+INTERACTIVE=yes
+[ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
 
 if [ ! -d .git ] ; then
     echo Not at top-level
@@ -16,19 +17,16 @@ fi
 while true ; do
     case "$1" in
     --tools)
-        WHAT=tools ; MERGE=yes ; BUILD=no ; shift
+        WHAT=tools ; BUILD=no ; shift
         ;;
     --web)
-        WHAT=web ; MERGE=yes ; BUILD=no ; shift
+        WHAT=web ; BUILD=no ; shift
         ;;
     --trivial)
         TRIVIAL="--trivial" ; shift
         ;;
-    --merge | --squash)
-        MERGE=yes ; shift
-        ;;
-    --nomerge | --nosquash)
-        MERGE=no ; shift
+    --squash
+        INTERACTIVE=no ; shift
         ;;
     --nobuild)
         BUILD=no ; shift
@@ -54,14 +52,21 @@ fi
 PRNUM=$1 ; shift
 TEAM=$*
 
-curl -s https://api.github.com/repos/openssl/$WHAT/pulls/$PRNUM >/tmp/gh$$
+PR_URL=https://api.github.com/repos/openssl/$WHAT/pulls/$PRNUM
+if ! wget --quiet $PR_URL -O /tmp/gh$$; then
+    echo "Error getting $PR_URL"
+    exit 1
+fi
 set -- `python -c '
 from __future__ import print_function
 import json, sys;
-print(str(json.load(sys.stdin)["head"]["label"]).replace(":", " "))' </tmp/gh$$`
-rm /tmp/gh$$
+input = json.load(sys.stdin)
+print(str(input["head"]["label"]).replace(":", " "),
+      str(input["head"]["repo"]["ssh_url"]))'        </tmp/gh$$`
 WHO=$1
 BRANCH=$2
+REPO=$3
+rm /tmp/gh$$
 
 if [ -z "$WHO" -o -z "$BRANCH" ]; then
     echo "Don't know from which branch to fetch"
@@ -71,6 +76,9 @@ fi
 REL=`git rev-parse --abbrev-ref HEAD`
 WORK="${WHO}-${BRANCH}"
 PREV=
+
+echo pulling latest $REL
+git pull
 
 git checkout -b $WORK $REL
 
@@ -82,30 +90,41 @@ function cleanup {
 }
 trap 'cleanup' EXIT
 
-git pull --rebase https://github.com/$WHO/$WHAT.git $BRANCH
+# append new commits from $REPO/$BRANCH
+git pull --rebase $REPO $BRANCH
+echo rebasing on $REL
 git rebase $REL
 
 echo Diff against $REL
 git diff $REL
 
-echo -n Press return to merge to $REL: ; read foo
+if [ "$INTERACTIVE" == "yes" ] ; then
+    echo -n "Press return to interactively rebase --autosquash on $REL: "; read foo
+    git rebase -i --autosquash $REL
+fi
+
 addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..
+echo Log since $REL
+git log $REL..
+
 git checkout $REL
-if [ "$MERGE" == "yes" ] ; then
-    git merge --no-commit --squash $WORK
+if [ "$INTERACTIVE" != "yes" ] ; then
+    echo -n "Press return to non-interactively merge --squash to $REL: "; read foo
+    git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
 else
-    git rebase $WORK
+    echo -n "Press return to merge to $REL: "; read foo
+    git merge --ff-only $WORK
 fi
 
 if [ "$BUILD" == "yes" ] ; then
-    echo Rebuilding
-    ( opensslbuild 2>&1 ) | tail -3
+    echo Rebuilding...
+    ( CC="$CC" opensslbuild 2>&1 ) | tail -3
 fi
 
 while true ; do
-    echo -n "Enter YES to push or NO to abort: "
+    echo -n "Enter 'yes' to push to origin/$REL or 'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ] ; then
@@ -114,5 +133,5 @@ while true ; do
 done
 
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
-    git push origin $REL
+    git push -v origin $REL
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -8,7 +8,7 @@ TRIVIAL=""
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 [ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
-REMOTE=origin
+REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1`
 
 if [ ! -d .git ] ; then
     echo Not at top-level
@@ -89,7 +89,7 @@ REL=`git rev-parse --abbrev-ref HEAD`
 WORK="${WHO}-${BRANCH}"
 PREV=
 
-echo -n "Press Enter to fetch and pull the latest $REL from $REMOTE: "; read foo
+echo -n "Press Enter to pull the latest $REL from $REMOTE: "; read foo
 git pull $REMOTE $REL
 
 git checkout -b $WORK $REL

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -8,6 +8,7 @@ TRIVIAL=""
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 [ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
+REMOTE=origin
 
 if [ ! -d .git ] ; then
     echo Not at top-level
@@ -34,6 +35,13 @@ while true ; do
         ;;
     --nobuild)
         BUILD=no ; shift
+        ;;
+    --remote)
+        if [ $# -lt 2 ] ; then
+            echo "Missing argument of '$1'"
+            exit 1
+        fi
+        shift; REMOTE=$1; shift
         ;;
     --)
         shift
@@ -81,8 +89,8 @@ REL=`git rev-parse --abbrev-ref HEAD`
 WORK="${WHO}-${BRANCH}"
 PREV=
 
-echo pulling latest $REL
-git pull
+echo -n "Press Enter to fetch and pull the latest $REL from $REMOTE: "; read foo
+git pull $REMOTE $REL
 
 git checkout -b $WORK $REL
 
@@ -128,7 +136,7 @@ if [ "$BUILD" == "yes" ] ; then
 fi
 
 while true ; do
-    echo -n "Enter 'yes' to push to origin/$REL or 'no' to abort: "
+    echo -n "Enter 'yes' to push to $REMOTE/$REL or 'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ] ; then
@@ -137,5 +145,5 @@ while true ; do
 done
 
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
-    git push -v origin $REL
+    git push -v $REMOTE $REL
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -92,20 +92,21 @@ PREV=
 echo -n "Press Enter to pull the latest $REL from $REMOTE: "; read foo
 git pull $REMOTE $REL
 
-git checkout -b $WORK $REL
-
 function cleanup {
     if [ "$WORK" != "$REL" ]; then
         git checkout -q $REL
         git branch -D $WORK
+        git reset --hard $REMOTE/$REL
     fi
 }
 trap 'cleanup' EXIT
 
+git checkout -b $WORK $REL
+
 # append new commits from $REPO/$BRANCH
 git pull --rebase $REPO $BRANCH
 echo rebasing on $REL
-git rebase $REL
+git rebase $REL || (git rebase --abort; exit 1)
 
 echo Diff against $REL
 git diff $REL
@@ -113,9 +114,9 @@ git diff $REL
 if [ "$INTERACTIVE" == "yes" ] ; then
     # echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REL: "; read foo
     git rebase -i $AUTOSQUASH $REL || (git rebase --abort; exit 1)
+    addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..
 fi
 
-addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..
 echo Log since $REL
 git log $REL..
 
@@ -125,10 +126,14 @@ if [ "$INTERACTIVE" != "yes" ] ; then
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
+    addrev $TRIVIAL --prnum=$PRNUM $TEAM $REMOTE/${REL}..
 else
     # echo -n "Press Enter to merge to $REL: "; read foo
     git merge --ff-only $WORK
 fi
+
+echo New log since $REMOTE/$REL
+git log $REMOTE/$REL..
 
 if [ "$BUILD" == "yes" ] ; then
     echo Rebuilding...

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -25,7 +25,7 @@ while true ; do
     --trivial)
         TRIVIAL="--trivial" ; shift
         ;;
-    --squash
+    --squash)
         INTERACTIVE=no ; shift
         ;;
     --nobuild)
@@ -99,7 +99,7 @@ echo Diff against $REL
 git diff $REL
 
 if [ "$INTERACTIVE" == "yes" ] ; then
-    echo -n "Press return to interactively rebase --autosquash on $REL: "; read foo
+    # echo -n "Press Enter to interactively rebase --autosquash on $REL: "; read foo
     git rebase -i --autosquash $REL
 fi
 
@@ -109,12 +109,12 @@ git log $REL..
 
 git checkout $REL
 if [ "$INTERACTIVE" != "yes" ] ; then
-    echo -n "Press return to non-interactively merge --squash to $REL: "; read foo
+    echo -n "Press Enter to non-interactively merge --squash to $REL: "; read foo
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
 else
-    echo -n "Press return to merge to $REL: "; read foo
+    # echo -n "Press Enter to merge to $REL: "; read foo
     git merge --ff-only $WORK
 fi
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -6,6 +6,7 @@ WHAT=openssl
 BUILD=yes
 TRIVIAL=""
 INTERACTIVE=yes
+AUTOSQUASH="--autosquash"
 [ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
 
 if [ ! -d .git ] ; then
@@ -24,6 +25,9 @@ while true ; do
         ;;
     --trivial)
         TRIVIAL="--trivial" ; shift
+        ;;
+    --noautosquash)
+        AUTOSQUASH="" ; shift
         ;;
     --squash)
         INTERACTIVE=no ; shift
@@ -99,8 +103,8 @@ echo Diff against $REL
 git diff $REL
 
 if [ "$INTERACTIVE" == "yes" ] ; then
-    # echo -n "Press Enter to interactively rebase --autosquash on $REL: "; read foo
-    git rebase -i --autosquash $REL || (git rebase --abort; exit 1)
+    # echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REL: "; read foo
+    git rebase -i $AUTOSQUASH $REL || (git rebase --abort; exit 1)
 fi
 
 addrev $TRIVIAL --prnum=$PRNUM $TEAM ${REL}..

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -43,7 +43,7 @@ echo "Are these correct?"
 
 while true
 do
-    echo -n "Enter YES to continue or NO to abort: "
+    echo -n "Enter 'yes' to continue or 'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ]
@@ -63,7 +63,7 @@ git cherry-pick -e -x $id
 
 while true
 do
-    echo -n "Enter YES to push or NO to abort: "
+    echo -n "Enter 'yes' to push or 'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ]


### PR DESCRIPTION
Various tweaks to make `ghmerge` more usable:
    * make gcc (rather than clang-3.6) the default for rebuilding
    * take the (SSH version of the) repo URL from the database
    * print some more (and slightly improve) info what is going on
    * show the log of the commits be pushed (after `addrev` is called)

Extend `review-tools/README`, making clear that `ghmerge` calls `addrev`

BTW, @mattcaswell, thanks for the Committer Instructions I had received by email.
I suggest adapting also these such that it becomes clear that  `ghmerge` uses `addrev`.
For instance:

```
Example usage adding PR and reviewer info to the last two commits:
$ addrev -2 --prnum=3711 matt @levitte master..

Example usage adding PR and reviewer info to the last commit and performing a non-merge push:
$ ghmerge --nomerge 3711 matt @levitte 
```

