### PR TITLE
[run-checker]: default to 4 parallel test jobs

### DIFF
--- a/run-checker/run-checker.sh
+++ b/run-checker/run-checker.sh
@@ -185,8 +185,9 @@ if run-hook prepare; then
                         rkill SIGKILL $testpid $BASHPID
                     ) 2> /dev/null &
 
+                    # If not set to another value, default to 4 test jobs
                     echo "  make test"
-                    OPENSSL_GOST_ENGINE_SO="$gost_engine" log-exec make test>>build.log 2>&1
+                    HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_GOST_ENGINE_SO="$gost_engine" log-exec make test >>build.log 2>&1
                 )
             ); then
                 echo "  PASS"


### PR DESCRIPTION
<https://github.com/openssl/openssl/pull/12326> added support for
running the tests in parallel. The default is still to run them
sequentially.

This alters run-checker so that it defaults to 4 test jobs in parallel,
which seems a safe assumption given we are already using 4 building
jobs.