### PR TITLE
Many small improvements of ghmerge and addrev

### DIFF
--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 my $args = "";
-my $filterargs = "HEAD^..";
+my $filterargs = "";
 my $list_reviewers = 0;
 my $help = 0;
 my $haveprnum = 0;
@@ -18,7 +18,8 @@ foreach (@ARGV) {
         $args .= "--reviewer=$_ ";
     } elsif (/^[-\w]+$/) {
         if (/^[0-9a-f]{7,}+/) {
-            $filterargs = "$_";
+            print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
+            $filterargs = $_;
         } else {
             $args .= "--reviewer=$_ ";
         }
@@ -46,6 +47,7 @@ foreach (@ARGV) {
     } elsif (/^--commit=(.+)$/) {
         $args .= "--commit=$1 ";
     } elsif (/^-(\d+)$/) {
+        print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
         $filterargs = "HEAD~$1..";
     } elsif (/^--list$/) {
 	$list_reviewers = 1;
@@ -54,9 +56,11 @@ foreach (@ARGV) {
 	$help = 1;
 	last;
     } else {
+        print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
         $filterargs = $_;
     }
 }
+$filterargs = "HEAD^.." if $filterargs eq "";
 
 if ($list_reviewers) {
     system("gitaddrev --list");

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -14,8 +14,14 @@ my $useself = 1;
 my $my_email;
 
 foreach (@ARGV) {
-    if (/^[a-z]+$/ || /^\@\w(?:[-\w]*\w)?$/) {
+    if (/^\@.+$/) {
         $args .= "--reviewer=$_ ";
+    } elsif (/^[-\w]+$/) {
+        if (/^[0-9a-f]{7,}+/) {
+            $filterargs = "$_";
+        } else {
+            $args .= "--reviewer=$_ ";
+        }
     } elsif (/^--reviewer=(.+)$/) {
         $args .= "--reviewer=$1 ";
     } elsif (/^--rmreviewers$/) {
@@ -98,7 +104,7 @@ option style arguments:
 
 non-option style arguments can be:
 
-a string of lower case letters, denoting a reviewer name.
+a string of alphanumeric or '-' characters, denoting a reviewer name.
 
 a string starting with \@, denoting a reviewer's github ID.
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -9,12 +9,12 @@ AUTOSQUASH="--autosquash"
 [ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
 REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1`
 if [ "$REMOTE" = "" ] ; then
-    echo Cannot find remote git.openssl.org
+    echo Cannot find git remote with URL including 'git.openssl.org'
     exit 1
 fi
 
 if [ ! -d .git ] ; then
-    echo Not at top-level
+    echo Not at a top-level git directory
     exit 1
 fi
 
@@ -58,9 +58,10 @@ while true ; do
         ;;
     esac
 done
+ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
 
 if [ $# -lt 2 ] ; then
-    echo "Usage: $0 [flags, including addrev flags] prnum reviewer..."
+    echo "Usage: $0 [flags, including addrev options] prnum reviewer..."
     exit 1
 fi
 PRNUM=$1 ; shift
@@ -82,8 +83,8 @@ BRANCH=$2
 REPO=$3
 rm /tmp/gh$$
 
-if [ -z "$WHO" -o -z "$BRANCH" ]; then
-    echo "Don't know from which branch to fetch"
+if [ -z "$WHO" -o -z "$BRANCH" -o -z "$REPO" ]; then
+    echo "Could not determine from $PR_URL which branch of whom to fetch from where"
     exit 1
 fi
 
@@ -97,7 +98,7 @@ git pull $REMOTE $REL
 function cleanup {
     if [ "$WORK" != "$REL" ]; then
         git checkout -q $REL
-        git branch -D $WORK
+        git branch -qD $WORK
         git reset --hard $REMOTE/$REL # prune any leftover commits added locally
     fi
 }
@@ -114,8 +115,9 @@ echo Diff against $REL
 git diff $REL
 
 if [ "$INTERACTIVE" == "yes" ] ; then
-    echo -n "Press Enter to interactively rebase $AUTOSQUASH $BRANCH on $REL: "; read foo
+    echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REL: "; read foo
     git rebase -i $AUTOSQUASH $REL || (git rebase --abort; exit 1)
+    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REL}.."
     addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REL}..
 fi
 
@@ -143,7 +145,7 @@ if [ "$BUILD" == "yes" ] ; then
 fi
 
 while true ; do
-    echo -n "Enter 'yes' to push to $REMOTE/$REL or 'no' to abort: "
+    echo -n "Enter 'y'/'yes' to push to $REMOTE/$REL or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ] ; then

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -19,9 +19,12 @@ if [ ! -d .git ] ; then
     exit 1
 fi
 
+PRNUM=
+TEAM=""
 ADDREVOPTS=""
 # Parse JCL.
-while true ; do
+shopt -s extglob
+while [ $# -ne 0 ]; do
     case "$1" in
     --tools)
         WHAT=tools ; BUILD=no ; shift
@@ -53,27 +56,43 @@ while true ; do
         shift; REL=$1; shift
         ;;
     --)
-        shift
+        if [ $# -lt 3 ] ; then
+            echo "Missing <prnum> <reviewer>... after '--'"
+            usage_exit
+        fi
+        shift; PRNUM=$1 ; shift
+        TEAM="$TEAM $*"
         break
         ;;
     -*) # e.g., --verbose, --trivial, --myemail=...
         ADDREVOPTS="$ADDREVOPTS $1"
         shift
-        break
         ;;
-    *)
-        break
+    +([[:digit:]]) ) # e.g., 1453
+        PRNUM=$1; shift
+        ;;
+    @*) # e.g., @t8m
+        TEAM="$TEAM $1"; shift
+        ;;
+    +([[:alnum:]-]) ) # e.g., levitte
+        if [[ $1 =~ ^[0-9a-f]{7,}+$ ]]; then # e.g., edd05b7
+            ADDREVOPTS="$ADDREVOPTS $1"
+        else
+            TEAM="$TEAM $1"
+        fi
+        shift
+        ;;
+    *) # e.g., edd05b7^^^^..19692bb2c32
+        ADDREVOPTS="$ADDREVOPTS $1"; shift
         ;;
     esac
 done
 ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
 
-if [ $# -lt 2 ] ; then
+if [ "$PRNUM" = "" -o "$TEAM" = "" ] ; then
     echo "Usage: $0 [flags, including addrev options] prnum reviewer..."
     exit 1
 fi
-PRNUM=$1 ; shift
-TEAM=$*
 
 PR_URL=https://api.github.com/repos/openssl/$WHAT/pulls/$PRNUM
 if ! wget --quiet $PR_URL -O /tmp/gh$$; then

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -151,9 +151,8 @@ trap 'cleanup' EXIT
 git checkout -b $WORK $REL
 
 # append new commits from $REPO/$BRANCH
-git pull --rebase $REPO $BRANCH
-echo rebasing $BRANCH on $REL
-git rebase $REL || (git rebase --abort; exit 1)
+echo Rebasing $REPO/$BRANCH on $REL...
+git pull --rebase $REPO $BRANCH || (git rebase --abort; exit 1)
 
 echo Diff against $REL
 git diff $REL

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -14,7 +14,7 @@ PICK=no
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 REMOTE=""
-REL=""
+REF=""
 BUILD=yes
 [ -z ${CC+x} ] && CC="ccache gcc" # opensslbuild will otherwise use "ccache clang-3.6"
 
@@ -60,7 +60,7 @@ while [ $# -ne 0 ]; do
             echo "Missing argument of '$1'"
             usage_exit
         fi
-        shift; REL=$1; shift
+        shift; REF=$1; shift
         ;;
     --)
         if [ $# -lt 3 ] ; then
@@ -127,14 +127,14 @@ if [ -z "$WHO" -o -z "$BRANCH" -o -z "$REPO" ]; then
     exit 1
 fi
 
-if [ "$REL" = "" ]; then
-    REL=`git rev-parse --abbrev-ref HEAD` # usually will be 'HEAD' or e.g., OpenSSL_1_1_1-stable
+if [ "$REF" = "" ]; then
+    REF=`git rev-parse --abbrev-ref HEAD` # usually will be 'HEAD' or e.g., OpenSSL_1_1_1-stable
 else
-    echo -n "Press Enter to checkout $REL: "; read foo
-    git checkout $REL
+    echo -n "Press Enter to checkout $REF: "; read foo
+    git checkout $REF
 fi
 
-echo -n "Press Enter to pull the latest $REMOTE/$REL: "; read foo
+echo -n "Press Enter to pull the latest $REMOTE/$REF: "; read foo
 git pull $REMOTE || (git rebase --abort; exit 1)
 
 WORK="copy-of-${WHO}-${BRANCH}"
@@ -143,53 +143,53 @@ function cleanup {
     rv=$?
     echo # new line
     [ $rv -ne 0 ] && echo -e "\nghmerge failed"
-    if [ "$WORK" != "$REL" ]; then
-        echo Restoring local $REL
-        git checkout -q $REL
+    if [ "$WORK" != "$REF" ]; then
+        echo Restoring local $REF
+        git checkout -q $REF
         git branch -qD $WORK 2>/dev/null
     fi
-    git reset --hard $REMOTE/$REL # prune any leftover commits added locally
+    git reset --hard $REMOTE/$REF # prune any leftover commits added locally
 }
 trap 'cleanup' EXIT
 
-git checkout -b $WORK $REL
+git checkout -b $WORK $REF
 
 # append new commits from $REPO/$BRANCH
 if [ "$PICK" != "yes" ]; then
-    echo Rebasing $REPO/$BRANCH on $REL...
+    echo Rebasing $REPO/$BRANCH on $REF...
     git pull --rebase $REPO $BRANCH || (git rebase --abort; exit 1)
 else
-    echo Cherry-picking $REPO/$BRANCH to $REL...
+    echo Cherry-picking $REPO/$BRANCH to $REF...
     git fetch $REPO $BRANCH && git cherry-pick FETCH_HEAD
 fi
 
-echo Diff against $REL
-git diff $REL
+echo Diff against $REF
+git diff $REF
 
 if [ "$INTERACTIVE" == "yes" ] ; then
-    echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REL: "; read foo
-    git rebase -i $AUTOSQUASH $REL || (git rebase --abort; exit 1)
-    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REL}.."
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REL}..
+    echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REF: "; read foo
+    git rebase -i $AUTOSQUASH $REF || (git rebase --abort; exit 1)
+    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REF}.."
+    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM ${REF}..
 fi
 
-echo Log since $REL
-git log $REL..
+echo Log since $REF
+git log $REF..
 
-git checkout $REL
+git checkout $REF
 if [ "$INTERACTIVE" != "yes" ] ; then
-    echo -n "Press Enter to non-interactively merge --squash $BRANCH to $REL: "; read foo
+    echo -n "Press Enter to non-interactively merge --squash $BRANCH to $REF: "; read foo
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${REL}..
+    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${REF}..
 else
-    # echo -n "Press Enter to merge to $REL: "; read foo
+    # echo -n "Press Enter to merge to $REF: "; read foo
     git merge --ff-only $WORK
 fi
 
-echo New log since $REMOTE/$REL
-git log $REMOTE/$REL..
+echo New log since $REMOTE/$REF
+git log $REMOTE/$REF..
 
 if [ "$BUILD" == "yes" ] ; then
     echo Rebuilding...
@@ -197,7 +197,7 @@ if [ "$BUILD" == "yes" ] ; then
 fi
 
 while true ; do
-    echo -n "Enter 'y'/'yes' to push to $REMOTE/$REL or 'n'/'no' to abort: "
+    echo -n "Enter 'y'/'yes' to push to $REMOTE/$REF or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ] ; then
@@ -206,5 +206,5 @@ while true ; do
 done
 
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
-    git push -v $REMOTE $REL
+    git push -v $REMOTE $REF
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+function usage_exit {
+    echo "Usage: $0 <options including prnum and reviewer(s)>"
+    echo "    or $0 [<options>] -- <prnum> <reviewer>..."
+    echo "Options may include addrev options and gitaddrev filter args."
+    exit 9
+}
+
 set -o errexit
 
 WHAT=openssl
@@ -40,14 +47,14 @@ while [ $# -ne 0 ]; do
     --remote)
         if [ $# -lt 2 ] ; then
             echo "Missing argument of '$1'"
-            exit 1
+            usage_exit
         fi
         shift; REMOTE=$1; shift
         ;;
     --ref)
         if [ $# -lt 2 ] ; then
             echo "Missing argument of '$1'"
-            exit 1
+            usage_exit
         fi
         shift; REL=$1; shift
         ;;
@@ -92,8 +99,7 @@ if [ "$REMOTE" = "" ] ; then
 fi
 
 if [ "$PRNUM" = "" -o "$TEAM" = "" ] ; then
-    echo "Usage: $0 [flags, including addrev options] prnum reviewer..."
-    exit 1
+    usage_exit
 fi
 
 PR_URL=https://api.github.com/repos/openssl/$WHAT/pulls/$PRNUM

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -10,6 +10,7 @@ function usage_exit {
 set -o errexit
 
 WHAT=openssl
+PICK=no
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 REMOTE=""
@@ -34,6 +35,9 @@ while [ $# -ne 0 ]; do
         ;;
     --web)
         WHAT=web ; BUILD=no ; shift
+        ;;
+    --cherry-pick)
+        PICK=yes ; shift
         ;;
     --noautosquash)
         AUTOSQUASH="" ; shift
@@ -151,8 +155,13 @@ trap 'cleanup' EXIT
 git checkout -b $WORK $REL
 
 # append new commits from $REPO/$BRANCH
-echo Rebasing $REPO/$BRANCH on $REL...
-git pull --rebase $REPO $BRANCH || (git rebase --abort; exit 1)
+if [ "$PICK" != "yes" ]; then
+    echo Rebasing $REPO/$BRANCH on $REL...
+    git pull --rebase $REPO $BRANCH || (git rebase --abort; exit 1)
+else
+    echo Cherry-picking $REPO/$BRANCH to $REL...
+    git fetch $REPO $BRANCH && git cherry-pick FETCH_HEAD
+fi
 
 echo Diff against $REL
 git diff $REL

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -1,9 +1,27 @@
 #! /bin/bash
 
 function usage_exit {
-    echo "Usage: $0 <options including prnum and reviewer(s)>"
-    echo "    or $0 [<options>] -- <prnum> <reviewer>..."
-    echo "Options may include addrev options and gitaddrev filter args."
+    >&2 echo "Usage: ghmerge <options including prnum and reviewer(s)>
+    or ghmerge [<options>] -- <prnum> <reviewer>...
+Options may include addrev options and gitaddrev filter args.
+
+Option style arguments:
+
+--help              Print this help and exit
+--tools             Merge a tools PR (rather than openssl PR)
+--web               Merge a web PR (rather than openssl PR)
+--remote <remote>   Merge with given repo (rather than implicit upstream)
+--ref <branch>      Merge with given branch (rather than impliict master)
+--cherry-pick       Use cherry-pick (rather than pull --rebase)
+--squash            Squash new commits non-interactively (allows editing msg)
+--noautosquash      Do not automatically squash fixups in interactive rebase
+--nobuild           Do not call 'openssbuild' before merging
+
+Examples:
+
+  ghmerge 12345 mattcaswell
+  ghmerge 12345 paulidale t8m --nobuild --myemail=dev@ddvo.net
+  ghmerge edd05b7^^^^..19692bb2c32 --squash -- 12345 levitte"
     exit 9
 }
 
@@ -30,6 +48,9 @@ ADDREVOPTS=""
 shopt -s extglob
 while [ $# -ne 0 ]; do
     case "$1" in
+    --help)
+        usage_exit
+        ;;
     --tools)
         WHAT=tools ; BUILD=no ; shift
         ;;

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -12,6 +12,7 @@ if [ "$REMOTE" = "" ] ; then
     echo Cannot find git remote with URL including 'git.openssl.org'
     exit 1
 fi
+REL=""
 
 if [ ! -d .git ] ; then
     echo Not at a top-level git directory
@@ -43,6 +44,13 @@ while true ; do
             exit 1
         fi
         shift; REMOTE=$1; shift
+        ;;
+    --ref)
+        if [ $# -lt 2 ] ; then
+            echo "Missing argument of '$1'"
+            exit 1
+        fi
+        shift; REL=$1; shift
         ;;
     --)
         shift
@@ -88,11 +96,17 @@ if [ -z "$WHO" -o -z "$BRANCH" -o -z "$REPO" ]; then
     exit 1
 fi
 
-REL=`git rev-parse --abbrev-ref HEAD`
+if [ "$REL" = "" ]; then
+    REL=`git rev-parse --abbrev-ref HEAD` # usually will be 'HEAD' or e.g., OpenSSL_1_1_1-stable
+else
+    echo -n "Press Enter to checkout $REL: "; read foo
+    git checkout $REL
+fi
 WORK="${WHO}-${BRANCH}"
 
-echo -n "Press Enter to pull the latest branch '$REL' from $REMOTE: "; read foo
-git pull $REMOTE $REL
+
+echo -n "Press Enter to pull the latest $REMOTE/$REL: "; read foo
+git pull $REMOTE || (git rebase --abort; exit 1)
 
 function cleanup {
     rv=$?

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -90,7 +90,6 @@ fi
 
 REL=`git rev-parse --abbrev-ref HEAD`
 WORK="${WHO}-${BRANCH}"
-PREV=
 
 echo -n "Press Enter to pull the latest branch '$REL' from $REMOTE: "; read foo
 git pull $REMOTE $REL

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -96,11 +96,15 @@ echo -n "Press Enter to pull the latest branch '$REL' from $REMOTE: "; read foo
 git pull $REMOTE $REL
 
 function cleanup {
+    rv=$?
+    echo # new line
+    [ $rv -ne 0 ] && echo -e "\nghmerge failed"
     if [ "$WORK" != "$REL" ]; then
+        echo Restoring local $REL
         git checkout -q $REL
-        git branch -qD $WORK
-        git reset --hard $REMOTE/$REL # prune any leftover commits added locally
+        git branch -qD $WORK 2>/dev/null
     fi
+    git reset --hard $REMOTE/$REL # prune any leftover commits added locally
 }
 trap 'cleanup' EXIT
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -102,11 +102,11 @@ else
     echo -n "Press Enter to checkout $REL: "; read foo
     git checkout $REL
 fi
-WORK="${WHO}-${BRANCH}"
-
 
 echo -n "Press Enter to pull the latest $REMOTE/$REL: "; read foo
 git pull $REMOTE || (git rebase --abort; exit 1)
+
+WORK="copy-of-${WHO}-${BRANCH}"
 
 function cleanup {
     rv=$?

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -7,11 +7,7 @@ BUILD=yes
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 [ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
-REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1`
-if [ "$REMOTE" = "" ] ; then
-    echo Cannot find git remote with URL including 'git.openssl.org'
-    exit 1
-fi
+REMOTE=""
 REL=""
 
 if [ ! -d .git ] ; then
@@ -88,6 +84,12 @@ while [ $# -ne 0 ]; do
     esac
 done
 ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
+
+[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1`
+if [ "$REMOTE" = "" ] ; then
+    echo Cannot find git remote with URL including 'git.openssl.org'
+    exit 1
+fi
 
 if [ "$PRNUM" = "" -o "$TEAM" = "" ] ; then
     echo "Usage: $0 [flags, including addrev options] prnum reviewer..."

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -179,7 +179,7 @@ git log $REMOTE/$REL..
 
 if [ "$BUILD" == "yes" ] ; then
     echo Rebuilding...
-    ( CC="$CC" opensslbuild 2>&1 ) | tail -3
+    CC="$CC" opensslbuild >/dev/null # any STDERR output will be shown
 fi
 
 while true ; do

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -3,12 +3,12 @@
 set -o errexit
 
 WHAT=openssl
-BUILD=yes
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
-[ -z ${CC+x} ] && CC="ccache gcc" # the default otherwise is "ccache clang-3.6"
 REMOTE=""
 REL=""
+BUILD=yes
+[ -z ${CC+x} ] && CC="ccache gcc" # opensslbuild will otherwise use "ccache clang-3.6"
 
 if [ ! -d .git ] ; then
     echo Not at a top-level git directory


### PR DESCRIPTION
addrev: 
* Improve flexibility providing reviewer names vs. commit refs (filter args) 
* Add warning on overriding filter args

ghmerge:
* Improve flexibility providing reviewer names vs. commit refs (gitaddrev filter args)
* Add `--cherry-pick` option (as alternative to rebase), useful for back-porting
* Add `--ref` option to checkout given reference at first
* Unify behavior on error in CLI arguments and improve usage output
* Make sure that on build error all error output is shown and then the tool exits
* Improve diagnostics on cleanup, distinguishing failure and non-error exit
* Various small improvements on user interaction, extending messages etc.
* Various minor code cleanups
