### PR TITLE
Improve ghmerge ref handling and documentation

### DIFF
--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -16,7 +16,7 @@ my $my_email;
 foreach (@ARGV) {
     if (/^(--prnum=)?(\d{1,6}+)$/) {
         $args .= "--prnum=$2 ";
-	$haveprnum = 1;
+        $haveprnum = 1;
     } elsif (/^\@.+$/) {
         $args .= "--reviewer=$_ ";
     } elsif (/^\w[-\w]*$/) {
@@ -43,18 +43,18 @@ foreach (@ARGV) {
     } elsif (/^--myemail=(.+)$/) {
         $my_email = $1;
     } elsif (/^--nopr$/) {
-	$haveprnum = 1;
+        $haveprnum = 1;
     } elsif (/^--commit=(.+)$/) {
         $args .= "--commit=$1 ";
     } elsif (/^-(\d+)$/) {
         print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
         $filterargs = "HEAD~$1..";
     } elsif (/^--list$/) {
-	$list_reviewers = 1;
-	last;
+        $list_reviewers = 1;
+        last;
     } elsif (/^--help$/ || /^-h$/) {
-	$help = 1;
-	last;
+        $help = 1;
+        last;
     } else {
         print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
         $filterargs = $_;
@@ -91,20 +91,18 @@ usage: addrev args...
 
 option style arguments:
 
---help			Print this help and exit
---list			List the known reviewers and exit (discards all other
-			arguments)
---verbose		Be a bit more verbose
---trivial		Do not require a CLA
---reviewer=<reviewer>	A reviewer to be added on a Reviewed-by: line
---rmreviewers		Remove all existing Reviewed-by: lines before adding
-			reviewers
---commit=<id>		Only apply to commit <id>
---myemail=<email>	Set email address.  Defaults to the result from
-			git configuration setting user.email
---nopr			Do not require a PR number
-[--prnum=]NNN           Add a reference to GitHub pull request NNN
--<n>			Change the last <n> commits.  Defaults to 1
+--help                 Print this help and exit
+--list                 List the known reviewers and exit (discards all other arguments)
+--verbose              Be a bit more verbose
+--trivial              Do not require a CLA
+--reviewer=<reviewer>  A reviewer to be added on a Reviewed-by: line
+--rmreviewers          Remove all existing Reviewed-by: lines before adding reviewers
+--commit=<id>          Only apply to commit <id>
+--myemail=<email>      Set email address.
+                       Defaults to the result from git configuration setting user.email
+--nopr                 Do not require a PR number
+[--prnum=]NNN          Add a reference to GitHub pull request NNN
+-<n>                   Change the last <n> commits.  Defaults to 1
 
 non-option style arguments can be:
 

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -16,7 +16,7 @@ my $my_email;
 foreach (@ARGV) {
     if (/^\@.+$/) {
         $args .= "--reviewer=$_ ";
-    } elsif (/^\w[-\w]+$/) {
+    } elsif (/^\w[-\w]*$/) {
         if (/^[0-9a-f]{7,}+/) {
             print "Warning: overriding previous filter args $filterargs\n" if $filterargs ne "";
             $filterargs = $_;

--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -14,7 +14,10 @@ my $useself = 1;
 my $my_email;
 
 foreach (@ARGV) {
-    if (/^\@.+$/) {
+    if (/^(--prnum=)?(\d{1,6}+)$/) {
+        $args .= "--prnum=$2 ";
+	$haveprnum = 1;
+    } elsif (/^\@.+$/) {
         $args .= "--reviewer=$_ ";
     } elsif (/^\w[-\w]*$/) {
         if (/^[0-9a-f]{7,}+/) {
@@ -40,9 +43,6 @@ foreach (@ARGV) {
     } elsif (/^--myemail=(.+)$/) {
         $my_email = $1;
     } elsif (/^--nopr$/) {
-	$haveprnum = 1;
-    } elsif (/^(--prnum=)?(\d+)$/) {
-        $args .= "--prnum=$2 ";
 	$haveprnum = 1;
     } elsif (/^--commit=(.+)$/) {
         $args .= "--commit=$1 ";
@@ -117,8 +117,8 @@ HEAD^.. is assumed.
 
 Examples (all meaning the same thing):
 
-  addrev -2 steve levitte
-  addrev steve \@levitte HEAD^^..
-  addrev --reviewer=steve --reviewer=levitte\@openssl.org -2
+  addrev 12345 -2 steve levitte
+  addrev --prnum=12345 steve \@levitte HEAD^^..
+  addrev 12345 --reviewer=steve --reviewer=levitte\@openssl.org -2
 EOF
 }

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -157,7 +157,7 @@ else
 fi
 
 echo -n "Press Enter to pull the latest $REMOTE/$REF: "; read foo
-git pull $REMOTE || (git rebase --abort; exit 1)
+git pull $REMOTE $REF || (git rebase --abort; exit 1)
 
 WORK="copy-of-${WHO}-${BRANCH}"
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -10,8 +10,8 @@ Option style arguments:
 --help              Print this help and exit
 --tools             Merge a tools PR (rather than openssl PR)
 --web               Merge a web PR (rather than openssl PR)
---remote <remote>   Merge with given repo (rather than implicit upstream)
---ref <branch>      Merge with given branch (rather than impliict master)
+--remote <remote>   Repo to merge with (rather than git.openssl.org), usually 'upstream'
+--ref <branch>      Branch to merge with (rather than current branch), usually 'master'
 --cherry-pick       Use cherry-pick (rather than pull --rebase)
 --squash            Squash new commits non-interactively (allows editing msg)
 --noautosquash      Do not automatically squash fixups in interactive rebase
@@ -21,7 +21,8 @@ Examples:
 
   ghmerge 12345 mattcaswell
   ghmerge 12345 paulidale t8m --nobuild --myemail=dev@ddvo.net
-  ghmerge edd05b7^^^^..19692bb2c32 --squash -- 12345 levitte"
+  ghmerge edd05b7^^^^..19692bb2c32 --squash -- 12345 levitte
+  ghmerge 12345 slontis --ref OpenSSL_1_1_1-stable"
     exit 9
 }
 
@@ -117,7 +118,7 @@ while [ $# -ne 0 ]; do
 done
 ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
 
-[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1`
+[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1` # usually this will be 'upstream'
 if [ "$REMOTE" = "" ] ; then
     echo Cannot find git remote with URL including 'git.openssl.org'
     exit 1
@@ -149,7 +150,7 @@ if [ -z "$WHO" -o -z "$BRANCH" -o -z "$REPO" ]; then
 fi
 
 if [ "$REF" = "" ]; then
-    REF=`git rev-parse --abbrev-ref HEAD` # usually will be 'HEAD' or e.g., OpenSSL_1_1_1-stable
+    REF=`git rev-parse --abbrev-ref HEAD` # usually this will be 'master' or, e.g., 'OpenSSL_1_1_1-stable'
 else
     echo -n "Press Enter to checkout $REF: "; read foo
     git checkout $REF


### PR DESCRIPTION
* `ghmerge`: Make pulling the latest REMOTE/REF work als for non-default REF
    
    This avoids potential git errors such as:
    
    You asked to pull from the remote 'upstream', but did not specify
    a branch. Because this is not the default configured remote
    for your current branch, you must specify a branch on the command line.

* `ghmerge`: improve doc of `--remote` and `--ref` options

* `addrev`: re-enable use of singe-character review names
