### PR TITLE
addrev: Silence the git filter-branch warning message

### DIFF
--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -82,6 +82,7 @@ if ($useself) {
 }
 
 my $err = "/tmp/addrev$$";
+$ENV{FILTER_BRANCH_SQUELCH_WARNING} = 1;
 system("git filter-branch -f --tag-name-filter cat --msg-filter \"gitaddrev $args\" $filterargs || (echo addrev failed; exit 1)");
 die if $?;
 


### PR DESCRIPTION
Just sets the environment variable so the git filter-branch warning message is silenced.
