### PR TITLE
run-checker: add more builds with FIPS enabled and other disabled.

### DIFF
--- a/run-checker/run-checker.sh
+++ b/run-checker/run-checker.sh
@@ -46,7 +46,13 @@ no-tls1_2-method no-dtls1-method no-dtls1_2-method no-siphash no-tls1_3 no-sm2
 no-sm3 no-sm4 enable-trace no-legacy no-cached-fetch no-autoload-config
 'no-buildtest-c++' no-bulk no-cmp no-ktls no-module no-padlockeng
 no-pinshared no-secure-memory no-siv no-uplink enable-acvp-tests enable-fips
-'enable-fips no-fips-securitychecks'
+'enable-fips no-fips-securitychecks' 'enable-fips enable-acvp-tests'
+'enable-fips no-cmac' 'enable-fips no-cmac' 'enable-fips no-des'
+'enable-fips no-dh' 'enable-fips no-dsa' 'enable-fips no-ec'
+'enable-fips no-ec2m' 'enable-fips no-ecdh' 'enable-fips no-ecdsa'
+'enable-fips no-tls' 'enable-fips no-tls1_1' 'enable-fips no-tls1'
+'enable-fips no-ssl3-method' 'enable-fips no-tls1-method'
+'enable-fips no-tls1_1-method' 'enable-fips no-tls1_3'
 )
 
 run-hook () {

--- a/run-checker/run-checker.sh
+++ b/run-checker/run-checker.sh
@@ -47,7 +47,7 @@ no-sm3 no-sm4 enable-trace no-legacy no-cached-fetch no-autoload-config
 'no-buildtest-c++' no-bulk no-cmp no-ktls no-module no-padlockeng
 no-pinshared no-secure-memory no-siv no-uplink enable-acvp-tests enable-fips
 'enable-fips no-fips-securitychecks' 'enable-fips enable-acvp-tests'
-'enable-fips no-cmac' 'enable-fips no-cmac' 'enable-fips no-des'
+'enable-fips no-cmac' 'enable-fips no-des'
 'enable-fips no-dh' 'enable-fips no-dsa' 'enable-fips no-ec'
 'enable-fips no-ec2m' 'enable-fips no-ecdh' 'enable-fips no-ecdsa'
 'enable-fips no-tls' 'enable-fips no-tls1_1' 'enable-fips no-tls1'

--- a/run-checker/run-checker.sh
+++ b/run-checker/run-checker.sh
@@ -47,9 +47,6 @@ no-sm3 no-sm4 enable-trace no-legacy no-cached-fetch no-autoload-config
 'no-buildtest-c++' no-bulk no-cmp no-ktls no-module no-padlockeng
 no-pinshared no-secure-memory no-siv no-uplink enable-acvp-tests enable-fips
 'enable-fips no-fips-securitychecks' 'enable-fips enable-acvp-tests'
-'enable-fips no-cmac' 'enable-fips no-des'
-'enable-fips no-dh' 'enable-fips no-dsa' 'enable-fips no-ec'
-'enable-fips no-ec2m' 'enable-fips no-ecdh' 'enable-fips no-ecdsa'
 'enable-fips no-tls' 'enable-fips no-tls1_1' 'enable-fips no-tls1'
 'enable-fips no-ssl3-method' 'enable-fips no-tls1-method'
 'enable-fips no-tls1_1-method' 'enable-fips no-tls1_3'


### PR DESCRIPTION
Not all of these work yet, this won't be merged until they do.

