### PR TITLE
Improve `pick-to-branch`

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -16,7 +16,7 @@ case $# in
     b=$2
     ;;
 1)
-    id=`git branch -v | awk '$2=="master" { print $3; }'`
+    id=`git branch -v | awk '$1=="master" { print $2; }'`
     b=$1
     ;;
 *)

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -3,6 +3,7 @@
 function usage {
     echo "Usage: pick-to-branch [<commit_id>] <branch>
     Cherry-pick a commit on the given target branch.
+    If this is no the current branch, the current branch and its state are preserved.
 
     If <commit_id>, intuit commit id from master.
     The <branch> arg must match a release branch or start with 'm' for master.
@@ -70,8 +71,29 @@ then
     exit 1
 fi
 
-git checkout --quiet master || exit 1
-git checkout $branch || exit 1
+
+ORIG_REF=`git rev-parse --abbrev-ref HEAD` # usually this will be 'master'
+if [ "$branch" != "$ORIG_REF" ]; then
+    STASH_OUT=`git stash`
+fi
+
+function cleanup {
+    rv=$?
+    echo # make sure to enter new line, needed, e.g., after Ctrl-C
+    [ $rv -ne 0 ] && echo -e "pick-to-branch failed"
+    if [ "$branch" != "$ORIG_REF" ]; then
+        echo Returning to previous branch $ORIG_REF
+        git checkout -q $ORIG_REF
+        if [ "$STASH_OUT" != "No local changes to save" ]; then
+            git stash pop -q # restore original state, pruning any leftover commits added locally
+        fi
+    fi
+}
+set -o errexit
+trap 'cleanup' EXIT
+
+git checkout --quiet master
+git checkout $branch
 git cherry-pick -e -x $id
 
 while true
@@ -89,5 +111,3 @@ if [ "$x" = "y" -o "$x" = "yes" ]
 then
     git push
 fi
-
-git checkout master

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -3,7 +3,7 @@
 function usage {
     echo "Usage: pick-to-branch [<commit_id>] <branch>
     Cherry-pick a commit on the given target branch.
-    If this is no the current branch, the current branch and its state are preserved.
+    If this is not the current branch, the current branch and its state are preserved.
 
     If <commit_id>, intuit commit id from master.
     The <branch> arg must match a release branch or start with 'm' for master.

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -1,6 +1,13 @@
 #! /bin/bash
 
-# If one arg, intuit commit id from master
+function usage {
+    echo "Usage: pick-to-branch [<commit_id>] <branch>
+    Cherry-pick a commit on the given target branch.
+
+    If <commit_id>, intuit commit id from master.
+    The <branch> arg must match a release branch or start with 'm' for master.
+    A release branch may be given simply as 102, 110, 111, 30, 31."
+}
 
 case $# in
 2)
@@ -12,7 +19,7 @@ case $# in
     b=$1
     ;;
 *)
-    echo "Usage $0 [commitid] branch"
+    usage
     exit 1
     ;;
 esac
@@ -31,6 +38,9 @@ case $b in
 *3*0*)
     branch=openssl-3.0
     ;;
+*3*1*)
+    branch=openssl-3.1
+    ;;
 m*)
     branch=master
     ;;
@@ -40,13 +50,13 @@ m*)
     ;;
 esac
 
-echo "id is $id"
-echo "branch is $branch"
+echo "commit id is $id"
+echo "target branch is $branch"
 echo "Are these correct?"
 
 while true
 do
-    echo -n "Enter 'yes' to continue or 'no' to abort: "
+    echo -n "Enter 'y'/'yes' to continue or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ]
@@ -66,7 +76,7 @@ git cherry-pick -e -x $id
 
 while true
 do
-    echo -n "Enter 'yes' to push or 'no' to abort: "
+    echo -n "Enter 'y'/'yes' to push or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ]

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -94,7 +94,7 @@ trap 'cleanup' EXIT
 
 git checkout --quiet master
 git checkout $branch
-git cherry-pick -e -x $id
+git cherry-pick -e -x $id || (git cherry-pick --abort; exit 1)
 
 while true
 do

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -2,7 +2,7 @@
 
 function usage {
     echo "Usage: pick-to-branch [<commit_id>] <branch>
-    Cherry-pick a commit on the given target branch.
+    Cherry-pick a commit on the given release target branch.
     If this is not the current branch, the current branch and its state are preserved.
 
     If <commit_id>, intuit commit id from master.
@@ -46,7 +46,7 @@ m*)
     branch=master
     ;;
 *)
-    echo Unknown branch
+    echo Unknown release target branch \'$b\'
     exit 1
     ;;
 esac

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -1,11 +1,12 @@
 #! /bin/bash
 
 function usage {
-    echo "Usage: pick-to-branch [<commit_id>] <branch>
+    echo "Usage: pick-to-branch [<id>] <branch>
     Cherry-pick a commit on the given release target branch.
     If this is not the current branch, the current branch and its state are preserved.
 
-    If <commit_id>, intuit commit id from master.
+    The commit can be given in the form of a branch name.
+    If no <id> arg is given, intuit commit id from master.
     The <branch> arg must match a release branch or start with 'm' for master.
     A release branch may be given simply as 102, 110, 111, 30, 31."
 }
@@ -51,9 +52,11 @@ m*)
     ;;
 esac
 
-echo "commit id is $id"
-echo "target branch is $branch"
-echo "Are these correct?"
+echo "Commit to chery-pick is:"
+git show $id | head -n 5
+echo
+echo "Target branch is: $branch"
+echo "Are both of these correct?"
 
 while true
 do


### PR DESCRIPTION
This has been motivated by https://github.com/openssl/tools/pull/94#issuecomment-939163365.
I found `pick-to-branch` rather cumbersome to use (as opposed to `ghmerge`),
but anyway made a quick pass over it, doing the following improvements:

* Improve error handling, as suggested in https://github.com/openssl/tools/pull/94#issuecomment-939163365
* Preserve current branch and its state if it is not the target
* Fix the case that commit id is derived from HEAD of master
* pick-to-branch: Improve user guidance
