### PR TITLE
pick-to-branch: fix inferring the id from master branch

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -6,7 +6,7 @@ function usage {
     If this is not the current branch, the current branch and its state are preserved.
 
     The commit can be given in the form of a branch name.
-    If no <id> arg is given, intuit commit id from master.
+    If no <id> arg is given, use the commit id of the HEAD of the master.
     The <branch> arg must match a release branch or start with 'm' for master.
     A release branch may be given simply as 102, 110, 111, 30, 31."
 }
@@ -17,7 +17,7 @@ case $# in
     b=$2
     ;;
 1)
-    id=`git branch -v | awk '$1=="master" { print $2; }'`
+    id=`git show -s --format="%H" master`
     b=$1
     ;;
 *)
@@ -52,7 +52,7 @@ m*)
     ;;
 esac
 
-echo "Commit to chery-pick is:"
+echo "Commit to chery-pick is $id:"
 git show $id | head -n 5
 echo
 echo "Target branch is: $branch"


### PR DESCRIPTION
The original way did not account for master being the currently active branch.