### PR TITLE
ghmerge: Fix behavior on failed cherry-pick

### DIFF
--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -11,7 +11,8 @@ Option style arguments:
 --tools             Merge a tools PR (rather than openssl PR)
 --web               Merge a web PR (rather than openssl PR)
 --remote <remote>   Repo to merge with (rather than git.openssl.org), usually 'upstream'
---ref <branch>      Branch to merge with (rather than current branch), usually 'master'
+--target <branch>   Merge target (rather than current branch), usually 'master'
+--ref <branch>      A synonym for --target
 --cherry-pick [<n>] Cherry-pick the last n (1 <= n <= 99, default: 1) commits, rather than rebasing
 --squash            Squash new commits non-interactively (allows editing msg)
 --noautosquash      Do not automatically squash fixups in interactive rebase
@@ -22,8 +23,8 @@ Examples:
   ghmerge 12345 mattcaswell
   ghmerge 12345 paulidale t8m --nobuild --myemail=dev@ddvo.net
   ghmerge edd05b7^^^^..19692bb2c32 --squash -- 12345 levitte
-  ghmerge 12345 slontis --ref openssl-3.0
-  ghmerge --nobuild --ref openssl-3.0 --cherry-pick 3 16051 paulidale"
+  ghmerge 12345 slontis --target openssl-3.0
+  ghmerge --nobuild --target openssl-3.0 --cherry-pick 3 16051 paulidale"
     exit 9
 }
 
@@ -34,7 +35,7 @@ PICK=no
 INTERACTIVE=yes
 AUTOSQUASH="--autosquash"
 REMOTE=""
-REF=""
+TARGET=""
 BUILD=yes
 [ -z ${CC+x} ] && CC="ccache gcc" # opensslbuild will otherwise use "ccache clang-3.6"
 
@@ -82,12 +83,12 @@ while [ $# -ne 0 ]; do
         fi
         shift; REMOTE=$1; shift
         ;;
-    --ref)
+    --target|--ref)
         if [ $# -lt 2 ] ; then
             echo "Missing argument of '$1'"
             usage_exit
         fi
-        shift; REF=$1; shift
+        shift; TARGET=$1; shift
         ;;
     --)
         if [ $# -lt 3 ] ; then
@@ -177,7 +178,7 @@ function cleanup {
         echo "Hint: maybe --cherry-pick was not given a suitable <n> parameter."
         git cherry-pick --abort 2>/dev/null || true
     fi
-    if [ "$REF" != "$ORIG_REF" ] || [ "$WORK_USED" != "" ]; then
+    if [ "$TARGET" != "$ORIG_REF" ] || [ "$WORK_USED" != "" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
     fi
@@ -190,64 +191,64 @@ function cleanup {
 }
 trap 'cleanup' EXIT
 
-[ "$REF" = "" ] && REF=$ORIG_REF
-if [ "$REF" != "$ORIG_REF" ]; then    
-    echo -n "Press Enter to checkout $REF: "; read foo
-    git checkout $REF
+[ "$TARGET" = "" ] && TARGET=$ORIG_REF
+if [ "$TARGET" != "$ORIG_REF" ]; then
+    echo -n "Press Enter to checkout $TARGET: "; read foo
+    git checkout $TARGET
 fi
 
-echo -n "Press Enter to pull the latest $REMOTE/$REF: "; read foo
+echo -n "Press Enter to pull the latest $REMOTE/$TARGET: "; read foo
 REBASING=1
-git pull $REMOTE $REF || exit 1
+git pull $REMOTE $TARGET || exit 1
 REBASING=
 
 WORK_USED=$WORK
 # append new commits from $REPO/$BRANCH
 if [ "$PICK" == "no" ]; then
-    echo Rebasing $REPO/$BRANCH on $REF...
+    echo Rebasing $REPO/$BRANCH on $TARGET...
     git fetch $REPO $BRANCH && git checkout -b $WORK FETCH_HEAD
     WORK_USED=$WORK
     REBASING=1
-    git rebase $REF || (echo 'Fix or Ctrl-d to abort' ; read || exit 1)
+    git rebase $TARGET || (echo 'Fix or Ctrl-d to abort' ; read || exit 1)
     REBASING=
 else
-    echo Cherry-picking $REPO/$BRANCH to $REF...
-    git checkout -b $WORK $REF
+    echo Cherry-picking $REPO/$BRANCH to $TARGET...
+    git checkout -b $WORK $TARGET
     WORK_USED=$WORK
     CHERRYPICKING=1
     git fetch $REPO $BRANCH && (git cherry-pick FETCH_HEAD~$PICK..FETCH_HEAD || exit 1)
     CHERRYPICKING=
 fi
 
-echo Diff against $REMOTE/$REF
-git diff $REMOTE/$REF
+echo Diff against $REMOTE/$TARGET
+git diff $REMOTE/$TARGET
 
 if [ "$INTERACTIVE" == "yes" ] ; then
-    echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REMOTE/$REF: "; read foo
+    echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REMOTE/$TARGET: "; read foo
     REBASING=1
-    git rebase -i $AUTOSQUASH $REMOTE/$REF || exit 1
+    git rebase -i $AUTOSQUASH $REMOTE/$TARGET || exit 1
     REBASING=
-    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$REF.."
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$REF..
+    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$TARGET.."
+    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$TARGET..
 fi
 
-echo Log since $REMOTE/$REF
-git log $REMOTE/$REF..
+echo Log since $REMOTE/$TARGET
+git log $REMOTE/$TARGET..
 
-git checkout $REF
+git checkout $TARGET
 if [ "$INTERACTIVE" != "yes" ] ; then
-    echo -n "Press Enter to non-interactively merge --squash $BRANCH to $REMOTE/$REF: "; read foo
+    echo -n "Press Enter to non-interactively merge --squash $BRANCH to $REMOTE/$TARGET: "; read foo
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${REF}..
+    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${TARGET}..
 else
-    # echo -n "Press Enter to merge to $REMOTE/$REF: "; read foo
+    # echo -n "Press Enter to merge to $REMOTE/$TARGET: "; read foo
     git merge --ff-only $WORK
 fi
 
-echo New log since $REMOTE/$REF
-git log $REMOTE/$REF..
+echo New log since $REMOTE/$TARGET
+git log $REMOTE/$TARGET..
 
 if [ "$BUILD" == "yes" ] ; then
     echo Rebuilding...
@@ -255,7 +256,7 @@ if [ "$BUILD" == "yes" ] ; then
 fi
 
 while true ; do
-    echo -n "Enter 'y'/'yes' to push to $REMOTE/$REF or 'n'/'no' to abort: "
+    echo -n "Enter 'y'/'yes' to push to $REMOTE/$TARGET or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
     if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ] ; then
@@ -264,5 +265,5 @@ while true ; do
 done
 
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
-    git push -v $REMOTE $REF
+    git push -v $REMOTE $TARGET
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -12,7 +12,7 @@ Option style arguments:
 --web               Merge a web PR (rather than openssl PR)
 --remote <remote>   Repo to merge with (rather than git.openssl.org), usually 'upstream'
 --ref <branch>      Branch to merge with (rather than current branch), usually 'master'
---cherry-pick       Use cherry-pick (rather than pull --rebase)
+--cherry-pick <n>   Cherry-pick the last n commits (rather than rebasing)
 --squash            Squash new commits non-interactively (allows editing msg)
 --noautosquash      Do not automatically squash fixups in interactive rebase
 --nobuild           Do not call 'openssbuild' before merging
@@ -22,7 +22,8 @@ Examples:
   ghmerge 12345 mattcaswell
   ghmerge 12345 paulidale t8m --nobuild --myemail=dev@ddvo.net
   ghmerge edd05b7^^^^..19692bb2c32 --squash -- 12345 levitte
-  ghmerge 12345 slontis --ref openssl-3.0"
+  ghmerge 12345 slontis --ref openssl-3.0
+  ghmerge --nobuild --ref openssl-3.0 --cherry-pick 3 16051 paulidale"
     exit 9
 }
 
@@ -59,7 +60,7 @@ while [ $# -ne 0 ]; do
         WHAT=web ; BUILD=no ; shift
         ;;
     --cherry-pick)
-        PICK=yes ; shift
+        shift; PICK=$1; shift
         ;;
     --noautosquash)
         AUTOSQUASH="" ; shift
@@ -197,7 +198,7 @@ REBASING=
 
 WORK_USED=$WORK
 # append new commits from $REPO/$BRANCH
-if [ "$PICK" != "yes" ]; then
+if [ "$PICK" == "" ]; then
     echo Rebasing $REPO/$BRANCH on $REF...
     git fetch $REPO $BRANCH && git checkout -b $WORK FETCH_HEAD
     WORK_USED=$WORK
@@ -209,7 +210,7 @@ else
     git checkout -b $WORK $REF
     WORK_USED=$WORK
     CHERRYPICKING=1
-    git fetch $REPO $BRANCH && (git cherry-pick FETCH_HEAD || exit 1)
+    git fetch $REPO $BRANCH && (git cherry-pick FETCH_HEAD~$PICK..FETCH_HEAD || exit 1)
     CHERRYPICKING=
 fi
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -174,6 +174,7 @@ function cleanup {
         git rebase --abort 2>/dev/null || true
     fi
     if [ "$CHERRYPICKING" == 1 ] ; then
+        echo "Hint: maybe --cherry-pick was not given a suitable <n> parameter."
         git cherry-pick --abort 2>/dev/null || true
     fi
     if [ "$REF" != "$ORIG_REF" ] || [ "$WORK_USED" != "" ]; then

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -165,6 +165,12 @@ function cleanup {
     rv=$?
     echo # make sure to enter new line, needed, e.g., after Ctrl-C
     [ $rv -ne 0 ] && echo -e "\nghmerge failed"
+    if [ "$REBASING" == 1 ] ; then
+        git rebase --abort 2>/dev/null || true
+    fi
+    if [ "$CHERRYPICKING" == 1 ] ; then
+        git cherry-pick --abort 2>/dev/null || true
+    fi
     if [ "$REF" != "$ORIG_REF" ] || [ "$WORK_USED" != "" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
@@ -185,7 +191,9 @@ if [ "$REF" != "$ORIG_REF" ]; then
 fi
 
 echo -n "Press Enter to pull the latest $REMOTE/$REF: "; read foo
-git pull $REMOTE $REF || (git rebase --abort; exit 1)
+REBASING=1
+git pull $REMOTE $REF || exit 1
+REBASING=
 
 WORK_USED=$WORK
 # append new commits from $REPO/$BRANCH
@@ -193,12 +201,16 @@ if [ "$PICK" != "yes" ]; then
     echo Rebasing $REPO/$BRANCH on $REF...
     git fetch $REPO $BRANCH && git checkout -b $WORK FETCH_HEAD
     WORK_USED=$WORK
-    git rebase $REF || (echo 'Fix or Ctrl-d to abort' ; read || (git rebase --abort; exit 1))
+    REBASING=1
+    git rebase $REF || (echo 'Fix or Ctrl-d to abort' ; read || exit 1)
+    REBASING=
 else
     echo Cherry-picking $REPO/$BRANCH to $REF...
     git checkout -b $WORK $REF
     WORK_USED=$WORK
-    git fetch $REPO $BRANCH && git cherry-pick FETCH_HEAD
+    CHERRYPICKING=1
+    git fetch $REPO $BRANCH && (git cherry-pick FETCH_HEAD || exit 1)
+    CHERRYPICKING=
 fi
 
 echo Diff against $REMOTE/$REF
@@ -206,7 +218,9 @@ git diff $REMOTE/$REF
 
 if [ "$INTERACTIVE" == "yes" ] ; then
     echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REMOTE/$REF: "; read foo
-    git rebase -i $AUTOSQUASH $REMOTE/$REF || (git rebase --abort; exit 1)
+    REBASING=1
+    git rebase -i $AUTOSQUASH $REMOTE/$REF || exit 1
+    REBASING=
     echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$REF.."
     addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$REF..
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -202,7 +202,7 @@ REBASING=
 
 WORK_USED=$WORK
 # append new commits from $REPO/$BRANCH
-if [ "$PICK" == "" ]; then
+if [ "$PICK" == "no" ]; then
     echo Rebasing $REPO/$BRANCH on $REF...
     git fetch $REPO $BRANCH && git checkout -b $WORK FETCH_HEAD
     WORK_USED=$WORK

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -62,7 +62,7 @@ while [ $# -ne 0 ]; do
     --cherry-pick)
         shift;
         PICK=1;
-        if [ $1 != "" ] && [ $1 -ge 1 ] && [ $1 -le 99 ]; then
+        if [ "$1" != "" ] && [ $1 -ge 1 ] && [ $1 -le 99 ]; then
             PICK=$1 ; shift
         fi
         ;;

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -178,6 +178,10 @@ function cleanup {
         echo "Hint: maybe --cherry-pick was not given a suitable <n> parameter."
         git cherry-pick --abort 2>/dev/null || true
     fi
+    if [ "$ORIG_TARGET_HEAD" != "" ]; then
+        echo Restoring original commit HEAD of $TARGET
+        git reset --hard "$ORIG_TARGET_HEAD"
+    fi
     if [ "$TARGET" != "$ORIG_REF" ] || [ "$WORK_USED" != "" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
@@ -186,7 +190,7 @@ function cleanup {
         git branch -qD $WORK_USED
     fi
     if [ "$STASH_OUT" != "No local changes to save" ]; then
-        git stash pop -q # restore original state, pruning any leftover commits added locally
+        git stash pop -q # restore original state of $ORIG_REF, pruning any leftover commits added locally
     fi
 }
 trap 'cleanup' EXIT
@@ -231,18 +235,23 @@ if [ "$INTERACTIVE" == "yes" ] ; then
     addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$TARGET..
 fi
 
+echo
 echo Log since $REMOTE/$TARGET
 git log $REMOTE/$TARGET..
 
 git checkout $TARGET
 if [ "$INTERACTIVE" != "yes" ] ; then
     echo -n "Press Enter to non-interactively merge --squash $BRANCH to $REMOTE/$TARGET: "; read foo
+    ORIG_TARGET_HEAD=`git show -s --format="%H"`
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
     addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${TARGET}..
 else
-    # echo -n "Press Enter to merge to $REMOTE/$TARGET: "; read foo
+    # echo -n "Press Enter to merge to $TARGET: "; read foo
+    echo
+    echo "Merging to $TARGET"
+    ORIG_TARGET_HEAD=`git show -s --format="%H"`
     git merge --ff-only $WORK
 fi
 
@@ -265,4 +274,5 @@ done
 
 if [ "$x" = "y" -o "$x" = "yes" ] ; then
     git push -v $REMOTE $TARGET
+    ORIG_TARGET_HEAD=
 fi

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -62,7 +62,7 @@ while [ $# -ne 0 ]; do
     --cherry-pick)
         shift;
         PICK=1;
-        if [ "$1" != "" ] && [ $1 -ge 1 ] && [ $1 -le 99 ]; then
+        if [ "$1" != "" ] && [ $1 -ge 1 ] 2>/dev/null && [ $1 -le 99 ]; then
             PICK=$1 ; shift
         fi
         ;;

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -12,7 +12,7 @@ Option style arguments:
 --web               Merge a web PR (rather than openssl PR)
 --remote <remote>   Repo to merge with (rather than git.openssl.org), usually 'upstream'
 --ref <branch>      Branch to merge with (rather than current branch), usually 'master'
---cherry-pick <n>   Cherry-pick the last n commits (rather than rebasing)
+--cherry-pick [<n>] Cherry-pick the last n (1 <= n <= 99, default: 1) commits, rather than rebasing
 --squash            Squash new commits non-interactively (allows editing msg)
 --noautosquash      Do not automatically squash fixups in interactive rebase
 --nobuild           Do not call 'openssbuild' before merging
@@ -60,7 +60,11 @@ while [ $# -ne 0 ]; do
         WHAT=web ; BUILD=no ; shift
         ;;
     --cherry-pick)
-        shift; PICK=$1; shift
+        shift;
+        PICK=1;
+        if [ $1 != "" ] && [ $1 -ge 1 ] && [ $1 -le 99 ]; then
+            PICK=$1 ; shift
+        fi
         ;;
     --noautosquash)
         AUTOSQUASH="" ; shift

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -202,7 +202,6 @@ REBASING=1
 git pull $REMOTE $TARGET || exit 1
 REBASING=
 
-WORK_USED=$WORK
 # append new commits from $REPO/$BRANCH
 if [ "$PICK" == "no" ]; then
     echo Rebasing $REPO/$BRANCH on $TARGET...


### PR DESCRIPTION
In case the cherry-pick failed, clean up the state
(as meanwhile done also by `pick-to-branch`).