### PR TITLE
pick-to-branch: improve branch handling

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -113,4 +113,6 @@ done
 if [ "$x" = "y" -o "$x" = "yes" ]
 then
     git push
+else
+    git reset --hard @~1
 fi

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -97,6 +97,7 @@ trap 'cleanup' EXIT
 
 git checkout --quiet master
 git checkout $branch
+git pull --ff-only
 git cherry-pick -e -x $id || (git cherry-pick --abort; exit 1)
 
 while true


### PR DESCRIPTION
* make sure that local copy of target branch is up-to-date
* revert cherry-pick if pick-to-branch is canceled in the last step by user answering 'no'
