### PR TITLE
pick-to-branch: Improve fix of behavior on failed cherry-pick

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -84,6 +84,9 @@ function cleanup {
     rv=$?
     echo # make sure to enter new line, needed, e.g., after Ctrl-C
     [ $rv -ne 0 ] && echo -e "pick-to-branch failed"
+    if [ "$CHERRYPICKING" == 1 ] ; then
+        git cherry-pick --abort 2>/dev/null || true
+    fi
     if [ "$branch" != "$ORIG_REF" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
@@ -98,7 +101,9 @@ trap 'cleanup' EXIT
 git checkout --quiet master
 git checkout $branch
 git pull --ff-only
+CHERRYPICKING=1
 git cherry-pick -e -x $id || (git cherry-pick --abort; exit 1)
+CHERRYPICKING=
 
 while true
 do


### PR DESCRIPTION
I meanwhile found that the recently merged solution is not sufficient
(namely, for situations where the user aborts cherry-picking etc. using Ctrl-C),
so this PR strengthens it.