### PR TITLE
pick-to-branch: Allow cherry-picking multiple commits at once

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -8,10 +8,13 @@ function usage {
     The commit can be given in the form of a branch name.
     If no <id> arg is given, use the commit id of the HEAD of the master.
     The <branch> arg must match a release branch or start with 'm' for master.
-    A release branch may be given simply as 102, 110, 111, 30, 31."
+    A release branch may be given simply as 102, 110, 111, 30, 31.
+
+    The <num> argument defaults to 1 and can be specified only in case <id> is
+    also given."
 }
 
-num=0
+num=1
 
 case $# in
 3)

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -62,11 +62,13 @@ m*)
     ;;
 esac
 
-echo "Commit to start cherry-picking is $id~$((num - 1)):"
-git show $id~$((num - 1)) | head -n 5
-echo
+echo "First commit to cherry-pick is: $id~$((num - 1))"
 echo "Target branch is: $branch"
 echo "Number of commits to pick: $num"
+echo "Commits to be cherry-picked:"
+echo
+git log $id~$num..$id
+echo
 echo "Are these correct?"
 
 while true

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 function usage {
-    echo "Usage: pick-to-branch [<id>] <branch>
-    Cherry-pick a commit on the given release target branch.
+    echo "Usage: pick-to-branch [<id>] <branch> [<num>]
+    Cherry-pick a commit (or <num> commits) on the given release target branch.
     If this is not the current branch, the current branch and its state are preserved.
 
     The commit can be given in the form of a branch name.
@@ -11,7 +11,14 @@ function usage {
     A release branch may be given simply as 102, 110, 111, 30, 31."
 }
 
+num=0
+
 case $# in
+3)
+    id=$1
+    b=$2
+    num=$(($3 - 1))
+    ;;
 2)
     id=$1
     b=$2
@@ -52,11 +59,12 @@ m*)
     ;;
 esac
 
-echo "Commit to chery-pick is $id:"
-git show $id | head -n 5
+echo "Commit to start cherry-picking is $id~$num:"
+git show $id~$num | head -n 5
 echo
 echo "Target branch is: $branch"
-echo "Are both of these correct?"
+echo "Number of commits to pick: $((num+1))"
+echo "Are these correct?"
 
 while true
 do
@@ -101,9 +109,11 @@ trap 'cleanup' EXIT
 git checkout --quiet master
 git checkout $branch
 git pull --ff-only
-CHERRYPICKING=1
-git cherry-pick -e -x $id || (git cherry-pick --abort; exit 1)
-CHERRYPICKING=
+for n in `seq $num -1 0` ; do
+    CHERRYPICKING=1
+    git cherry-pick -e -x $id~$n || (git cherry-pick --abort; exit 1)
+    CHERRYPICKING=
+done
 
 while true
 do

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -17,7 +17,7 @@ case $# in
 3)
     id=$1
     b=$2
-    num=$(($3 - 1))
+    num=$3
     ;;
 2)
     id=$1
@@ -59,11 +59,11 @@ m*)
     ;;
 esac
 
-echo "Commit to start cherry-picking is $id~$num:"
-git show $id~$num | head -n 5
+echo "Commit to start cherry-picking is $id~$((num - 1)):"
+git show $id~$((num - 1)) | head -n 5
 echo
 echo "Target branch is: $branch"
-echo "Number of commits to pick: $((num+1))"
+echo "Number of commits to pick: $num"
 echo "Are these correct?"
 
 while true
@@ -109,11 +109,9 @@ trap 'cleanup' EXIT
 git checkout --quiet master
 git checkout $branch
 git pull --ff-only
-for n in `seq $num -1 0` ; do
-    CHERRYPICKING=1
-    git cherry-pick -e -x $id~$n || (git cherry-pick --abort; exit 1)
-    CHERRYPICKING=
-done
+CHERRYPICKING=1
+git cherry-pick -e -x $id~$num..$id || (git cherry-pick --abort; exit 1)
+CHERRYPICKING=
 
 while true
 do


### PR DESCRIPTION
This can be quite handy when merging multiple-commit PRs to release branches.