### PR TITLE
`pick-to branch`: improve guidance; restore branch on error/abort, etc.

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -1,14 +1,14 @@
 #! /bin/bash
 
 function usage {
-    echo "Usage: pick-to-branch [<id>] <target> [<num>]
+    echo "Usage: pick-to-branch [<id> | h | HEAD ] <target> [<num>]
 
     Cherry-pick a commit (or <num> commits) on the given target release branch.
     If this is not the current branch, the current branch and its state are preserved.
 
     The optional <id> arg specifies the ID of the (last) commit to cherry-pick.
-    It can be given in the form of a branch name.
-    If no <id> arg is given, the commit id of the HEAD of the master is used.
+    It can also be given in the form of a branch name.  If 'h' or 'HEAD'
+    or no <id> arg is given, the commit id of the HEAD of the master is used.
 
     The <target> arg must match a release branch or start with 'm' for master.
     A release branch may be given simply as 102, 110, 111, 30, 31.
@@ -37,6 +37,10 @@ case $# in
     usage
     exit 1
     ;;
+esac
+
+case $id in
+    h|HEAD) id=`git show -s --format="%H" master`;;
 esac
 
 

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -88,6 +88,10 @@ function cleanup {
         echo "cherry-picking failed - maybe did not provide a suitable <num> argument?"
         git cherry-pick --abort 2>/dev/null || true
     fi
+    if [ "$ORIG_TARGET_HEAD" != "" ]; then
+        echo Restoring original commit HEAD of $TARGET
+        git reset --merge "$ORIG_TARGET_HEAD"
+    fi
     if [ "$target" != "$ORIG_REF" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
@@ -101,13 +105,13 @@ trap 'cleanup' EXIT
 
 git checkout --quiet master
 git checkout $target
+ORIG_TARGET_HEAD=`git show -s --format="%H"`
 git pull --ff-only
 CHERRYPICKING=1
 git cherry-pick -e -x $id~$num..$id || (git cherry-pick --abort; exit 1)
 CHERRYPICKING=
 
-while true
-do
+while true ; do
     echo -n "Enter 'y'/'yes' to push or 'n'/'no' to abort: "
     read x
     x="`echo $x | tr A-Z a-z`"
@@ -117,9 +121,7 @@ do
     fi
 done
 
-if [ "$x" = "y" -o "$x" = "yes" ]
-then
+if [ "$x" = "y" -o "$x" = "yes" ] ; then
     git push
-else
-    git reset --hard @~1
+    ORIG_TARGET_HEAD=
 fi

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -1,16 +1,16 @@
 #! /bin/bash
 
 function usage {
-    echo "Usage: pick-to-branch [<id>] <branch> [<num>]
+    echo "Usage: pick-to-branch [<id>] <target> [<num>]
 
-    Cherry-pick a commit (or <num> commits) on the given release target branch.
+    Cherry-pick a commit (or <num> commits) on the given target release branch.
     If this is not the current branch, the current branch and its state are preserved.
 
     The optional <id> arg specifies the ID of the (last) commit to cherry-pick.
     It can be given in the form of a branch name.
     If no <id> arg is given, the commit id of the HEAD of the master is used.
 
-    The <branch> arg must match a release branch or start with 'm' for master.
+    The <target> arg must match a release branch or start with 'm' for master.
     A release branch may be given simply as 102, 110, 111, 30, 31.
 
     The optional <num> argument specifies the number of commits to cherry-pick.
@@ -42,31 +42,31 @@ esac
 
 case $b in
 *1*0*2*)
-    branch=OpenSSL_1_0_2-stable
+    target=OpenSSL_1_0_2-stable
     ;;
 *1*1*0*)
-    branch=OpenSSL_1_1_0-stable
+    target=OpenSSL_1_1_0-stable
     ;;
 *1*1*1*)
-    branch=OpenSSL_1_1_1-stable
+    target=OpenSSL_1_1_1-stable
     ;;
 *3*0*)
-    branch=openssl-3.0
+    target=openssl-3.0
     ;;
 *3*1*)
-    branch=openssl-3.1
+    target=openssl-3.1
     ;;
 m*)
-    branch=master
+    target=master
     ;;
 *)
-    echo Unknown release target branch \'$b\'
+    echo Unknown target release branch \'$b\'
     exit 1
     ;;
 esac
 
 echo "First commit to cherry-pick is: $id~$((num - 1))"
-echo "Target branch is: $branch"
+echo "Target branch is: $target"
 echo "Number of commits to pick: $num"
 echo "Commit(s) to be cherry-picked:"
 echo
@@ -76,7 +76,7 @@ echo
 echo -n "Press Enter to continue, Ctrl-C to abort:"; read foo
 
 ORIG_REF=`git rev-parse --abbrev-ref HEAD` # usually this will be 'master'
-if [ "$branch" != "$ORIG_REF" ]; then
+if [ "$target" != "$ORIG_REF" ]; then
     STASH_OUT=`git stash`
 fi
 
@@ -88,7 +88,7 @@ function cleanup {
         echo "cherry-picking failed - maybe did not provide a suitable <num> argument?"
         git cherry-pick --abort 2>/dev/null || true
     fi
-    if [ "$branch" != "$ORIG_REF" ]; then
+    if [ "$target" != "$ORIG_REF" ]; then
         echo Returning to previous branch $ORIG_REF
         git checkout -q $ORIG_REF
         if [ "$STASH_OUT" != "No local changes to save" ]; then
@@ -100,7 +100,7 @@ set -o errexit
 trap 'cleanup' EXIT
 
 git checkout --quiet master
-git checkout $branch
+git checkout $target
 git pull --ff-only
 CHERRYPICKING=1
 git cherry-pick -e -x $id~$num..$id || (git cherry-pick --abort; exit 1)

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -2,16 +2,19 @@
 
 function usage {
     echo "Usage: pick-to-branch [<id>] <branch> [<num>]
+
     Cherry-pick a commit (or <num> commits) on the given release target branch.
     If this is not the current branch, the current branch and its state are preserved.
 
-    The commit can be given in the form of a branch name.
-    If no <id> arg is given, use the commit id of the HEAD of the master.
+    The optional <id> arg specifies the ID of the (last) commit to cherry-pick.
+    It can be given in the form of a branch name.
+    If no <id> arg is given, the commit id of the HEAD of the master is used.
+
     The <branch> arg must match a release branch or start with 'm' for master.
     A release branch may be given simply as 102, 110, 111, 30, 31.
 
-    The <num> argument defaults to 1 and can be specified only in case <id> is
-    also given."
+    The optional <num> argument specifies the number of commits to cherry-pick.
+    It defaults to 1 and can be specified only in case <id> is also given."
 }
 
 num=1
@@ -65,28 +68,12 @@ esac
 echo "First commit to cherry-pick is: $id~$((num - 1))"
 echo "Target branch is: $branch"
 echo "Number of commits to pick: $num"
-echo "Commits to be cherry-picked:"
+echo "Commit(s) to be cherry-picked:"
 echo
 git log $id~$num..$id
 echo
-echo "Are these correct?"
 
-while true
-do
-    echo -n "Enter 'y'/'yes' to continue or 'n'/'no' to abort: "
-    read x
-    x="`echo $x | tr A-Z a-z`"
-    if [ "$x" = "y" -o "$x" = "yes" -o "$x" = "n" -o "$x" = "no" ]
-    then
-        break
-    fi
-done
-
-if [ "$x" = "n" -o "$x" = "no" ]
-then
-    exit 1
-fi
-
+echo -n "Press Enter to continue, Ctrl-C to abort:"; read foo
 
 ORIG_REF=`git rev-parse --abbrev-ref HEAD` # usually this will be 'master'
 if [ "$branch" != "$ORIG_REF" ]; then
@@ -98,6 +85,7 @@ function cleanup {
     echo # make sure to enter new line, needed, e.g., after Ctrl-C
     [ $rv -ne 0 ] && echo -e "pick-to-branch failed"
     if [ "$CHERRYPICKING" == 1 ] ; then
+        echo "cherry-picking failed - maybe did not provide a suitable <num> argument?"
         git cherry-pick --abort 2>/dev/null || true
     fi
     if [ "$branch" != "$ORIG_REF" ]; then

--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -110,7 +110,7 @@ trap 'cleanup' EXIT
 git checkout --quiet master
 git checkout $target
 ORIG_TARGET_HEAD=`git show -s --format="%H"`
-git pull --ff-only
+git pull --ff-only `git rev-parse --abbrev-ref  @{u} | sed "s|/| |"`
 CHERRYPICKING=1
 git cherry-pick -e -x $id~$num..$id || (git cherry-pick --abort; exit 1)
 CHERRYPICKING=


### PR DESCRIPTION
* restore original commit HEAD of target on error/abort
* improve user guidance and streamline interaction
* allow 'h' or 'HEAD' as first argument, which leads to using the master HEAD
* pick-to-branch: rename 'branch' to 'target' for clarity
* restrict 'git pull --ff-only' to target branch

