### PR TITLE
ghmerge: The default remote is on github.openssl.org

### DIFF
--- a/review-tools/README
+++ b/review-tools/README
@@ -113,12 +113,13 @@ It includes several safety precautions and questions such as showing the diff,
 showing the resulting commit messages, and (by default) rebuilding everything.
 
 It works on the current branch, which should be 'master' or one of the stable
-releases. The default remote is the first one matching 'git.openssl.org.*(push)'.
-So typically before calling 'ghmerge' one would have done the following:
+releases. The default remote is the first one matching
+'github.openssl.org:(openssl|omc|otc).*(push)'. So typically before calling
+'ghmerge' one would have done the following:
 
 	git remote -v
-origin	openssl-git@git.openssl.org:openssl.git (fetch)
-origin	openssl-git@git.openssl.org:openssl.git (push)
+origin	openssl-git@github.openssl.org:openssl/openssl.git (fetch)
+origin	openssl-git@github.openssl.org:openssl/openssl.git (push)
 	git fetch origin
 	git checkout master
 

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -130,9 +130,9 @@ else
 fi
 ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
 
-[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk '/git.openssl.org.*(push)/{ print $1; }' | head -n 1` # usually this will be 'upstream'
+[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk '/github.openssl.org:(openssl|omc|otc).*(push)/{ print $1; }' | head -n 1` # usually this will be 'upstream'
 if [ "$REMOTE" = "" ] ; then
-    echo Cannot find git remote with URL including 'git.openssl.org'
+    echo Cannot find git remote with URL including 'github.openssl.org'
     exit 1
 fi
 


### PR DESCRIPTION
The tools repo has been already moved to github.openssl.org.
