### PR TITLE
pick-to-branch: Allow fixing trivial conflicts when cherry-picking

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -112,7 +112,7 @@ git checkout $target
 ORIG_TARGET_HEAD=`git show -s --format="%H"`
 git pull --ff-only `git rev-parse --abbrev-ref  @{u} | sed "s|/| |"`
 CHERRYPICKING=1
-git cherry-pick -e -x $id~$num..$id || (git cherry-pick --abort; exit 1)
+git cherry-pick -e -x $id~$num..$id || (echo 'Fix or Ctrl-d to abort' ; read || exit 1)
 CHERRYPICKING=
 
 while true ; do


### PR DESCRIPTION
A trivial enhancement to allow fixing trivial conflicts when cherry-picking.
