### PR TITLE
In HOWTO-make-a-release.md, include what's needed for premium releases

### DIFF
--- a/HOWTO-make-a-release.md
+++ b/HOWTO-make-a-release.md
@@ -272,13 +272,11 @@ data repo*
 
     If there is a Security Advisory then copy it into the secadv directory.
 
-Commit your changes, but *do not push* them to the release data repo at this
-stage.  (the release data repo being `git@github.openssl.org:omc/data.git`)
+Make a pull request from your changes, against the release data repo (the
+release data repo being `git@github.openssl.org:omc/data.git`).
 
-*Do* send the commits to the reviewer and await their approval.  It's
-advisable to use this command to get a copy of those commits:
-
-    git format-patch
+*Do not merge the pull request at this point*, even if the reviewer already
+approved it.
 
 # Publish the release
 
@@ -326,12 +324,17 @@ option. You must specify the repository / remote and tag to be pushed:
 
 ## Updating the release data
 
-If you committed anything to the release data repo, push the changes now.
+If there is a PR against the release repo to be merged, perform the merge
+now.
 
 When you do this for a public release, the website will get updated and a
-script to flush the Akamai CDN cache will be run.  You can look at things on
-www-origin.openssl.org; the CDN-hosted www.openssl.org should only be a few
-minutes delayed.
+script to flush the Akamai CDN cache will be run.
+
+You can look at <https://automation.openssl.org/> to see the automation
+builds in action.  The builder called `web` is of particular interest.
+
+You can also look at the result at <https://www-origin.openssl.org>; the
+CDN-hosted www.openssl.org should get updated withing minutes later.
 
 # Post-publishing tasks
 

--- a/HOWTO-make-a-release.md
+++ b/HOWTO-make-a-release.md
@@ -324,8 +324,8 @@ option. You must specify the repository / remote and tag to be pushed:
 
 ## Updating the release data
 
-If there is a PR against the release repo to be merged, perform the merge
-now.
+If there is a PR against the release data repo to be merged, perform the
+merge now.
 
 When you do this for a public release, the website will get updated and a
 script to flush the Akamai CDN cache will be run.

--- a/HOWTO-make-a-release.md
+++ b/HOWTO-make-a-release.md
@@ -16,7 +16,7 @@ and additional tester.
     -   [A method for reviewing](#a-way-to-reviewing)
 -   [Pre-publishing tasks](#pre-publishing-tasks)
     -   [Prepare your repository checkouts](#prepare-your-repository-checkouts)
-    -   [Freeze the source repository](#freeze-the-source-repository) [the day before release]
+    -   [Freeze the source repository](#freeze-the-source-repository) [three business days before release]
     -   [Make sure that the openssl source is up to date](#make-sure-that-the-openssl-source-is-up-to-date)
     -   [Generate the tarball and announcement text](#generating-the-tarball-and-announcement-text)
         -   [OpenSSL 3.0 and on](#openssl-3.0-and-on)
@@ -313,13 +313,9 @@ www.openssl.org should only be a few minutes delayed.
 ## Check the website
 
 Verify that the release notes, which are built from the CHANGES.md file
-in the release, have been updated.  This is done automatically by the
-commit-hook, but if you see a problem, try the following steps on
-`dev.openssl.org`:
-
-    cd /var/www/openssl
-    sudo -u openssl -H make relupd
-    sudo -u openssl -H ./bin/purge-one-hour
+in the release, have been updated.  This is done automatically by OpenSSL
+automation; if you see a problem, check if the web build job has been
+performed yet, you may have to wait a few minutes before it kicks in.
 
 Wait for a while for the Akamai flush to work (normally within a few minutes).
 Have a look at the website and news announcement at:

--- a/HOWTO-make-a-release.md
+++ b/HOWTO-make-a-release.md
@@ -199,8 +199,8 @@ Reviewed-By trailers as required.
 approval.
 
 *Do not push* changes to the source repo at this stage.
-(the source repo being on of `git@github.openssl.org:openssl/openssl.git` or
-`git@github.openssl.org:openssl/premium.git`)
+(the source repo being one of `git@github.openssl.org:openssl/openssl.git`
+or `git@github.openssl.org:openssl/premium.git`)
 
 ## Generate the tarball and announcement text
 
@@ -224,8 +224,8 @@ match in the .md5, .sha1, .sha256, and review the announcment file.
 approval.
 
 *Do not push* changes to the source repo at this stage.
-(the source repo being on of `git@github.openssl.org:openssl/openssl.git` or
-`git@github.openssl.org:openssl/premium.git`)
+(the source repo being one of `git@github.openssl.org:openssl/openssl.git`
+or `git@github.openssl.org:openssl/premium.git`)
 
 ### OpenSSL 3.0 and on
 


### PR DESCRIPTION
Premium releases aren't terribly different from public releases, it's all in the details.

There were a couple of other details that had aged and weren't current any more, they are fixed too.

