### PR TITLE
`ghmerge`: support handling conflicts on interactive rebase

### DIFF
--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -235,7 +235,7 @@ if [ "$INTERACTIVE" == "yes" ] ; then
     echo
     echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REMOTE/$TARGET: "; read foo
     REBASING=1
-    git rebase -i $AUTOSQUASH $REMOTE/$TARGET || exit 1
+    git rebase -i $AUTOSQUASH $REMOTE/$TARGET || (echo -ne "Press Ctrl-d to abort, or fix the issue in another shell,\n    run 'git rebase --continue' there, and on success press Enter here: "; read || exit 1)
     if [ -e .git/rebase-merge ] ; then  # likely, user tried 'b' or 'e' command to break or enter edit mode
         echo -e "\nRebasing was stopped; please do your changes in parallel using another\n shell in the same directory, then give 'git rebase --continue' there"
         while [ -e .git/rebase-merge ] ; do sleep 1 ; done


### PR DESCRIPTION
This is a follow-up on #126 and #129.
Allow handling conflicts also on 2nd type of rebase.