### PR TITLE
release-tools/do-copyright-year: Modify files with more care

### DIFF
--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -47,8 +47,22 @@ git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
 	    if [ -d "$FILE" ]; then continue; fi
 	    (( count++ ))
 	    spin $count
-	    sed -E -f /tmp/sed$$ -i "$FILE"
-	    git add "$FILE"
+	    # To avoid touching the original files when they aren't modified:
+	    #
+	    # 1. Copy the file, to make sure all permissions and other
+	    #	 copyable attributes are copied as well
+	    # 2. Run sed on the copy
+	    # 3. IF the copy has been modified, move it back to the original,
+	    #	 add and commit.
+	    TMPFILE="$(dirname "$FILE")"/"__$(basename "$FILE").new"
+	    cp "$FILE" "$TMPFILE"
+	    sed -E -f /tmp/sed$$ -i "$TMPFILE"
+	    if cmp -s "$FILE" "$TMPFILE"; then
+		rm "$TMPFILE"
+	    else
+		mv "$TMPFILE" "$FILE"
+		git add "$FILE"
+	    fi
 	done
 	endspin "Files considered: $count"
     )


### PR DESCRIPTION
Files were modified by running a simple in-place sed (i.e. 'sed -i').
This turns out to update the modification time on every file, even those
that remain unmodified.

The effect is that time stamps in a source directory become unreliable,
causing configdata.pm to be "mysteriously" older than (unmodified) files it
depends on, which causes a spurious reconfiguration when running 'make'
again.

To mediate, the loop is modified to take copies of the original files, run
an in-place sed on those, and only move them back to the original files if
there were any actual modifications.  That should leave time stamps alone on
unmodified files.
