### PR TITLE
Add a performance test for OSSL_PROVIDER_do_all()

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -1,7 +1,7 @@
-all: randbytes handshake sslnew newrawkey rsasign
+all: randbytes handshake sslnew newrawkey rsasign providerdoall
 
 clean:
-	rm libperf.a *.o randbytes handshake sslnew newrawkey rsasign
+	rm libperf.a *.o randbytes handshake sslnew newrawkey rsasign providerdoall
 
 libperf.a: perflib/*.c perflib/*.h
 	gcc -I$(TARGET_OSSL_INCLUDE_PATH) -I. -c perflib/*.c
@@ -21,3 +21,6 @@ newrawkey:	newrawkey.c libperf.a
 
 rsasign: rsasign.c libperf.a
 	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o rsasign rsasign.c -lperf -lcrypto
+
+providerdoall:	providerdoall.c libperf.a
+	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o providerdoall providerdoall.c -lperf -lcrypto

--- a/perf/README
+++ b/perf/README
@@ -94,5 +94,5 @@ providerdoall
 
 The providerdoall test repeated calls the OSSL_PROVIDER_do_all() function in
 blocks of 100 calls, and 100 blocks per thread. The number of threads to use is
-provided as an argument and the test reports the total time taken divided by
-the total number of blocks.
+provided as an argument and the test reports the average time take to execute a
+block of 100 OSSL_PROVIDER_do_all() calls.

--- a/perf/README
+++ b/perf/README
@@ -88,3 +88,11 @@ functions in blocks of 100 calls, and 100 blocks per thread, using a 512 bit RSA
 key. The number of threads to use is provided as an argument and the test
 reports the average time take to execute a block of 100
 EVP_PKEY_sign_init()/EVP_PKEY_sign() calls.
+
+providerdoall
+-------------
+
+The providerdoall test repeated calls the OSSL_PROVIDER_do_all() function in
+blocks of 100 calls, and 100 blocks per thread. The number of threads to use is
+provided as an argument and the test reports the total time taken divided by
+the total number of blocks.

--- a/perf/README
+++ b/perf/README
@@ -92,7 +92,7 @@ EVP_PKEY_sign_init()/EVP_PKEY_sign() calls.
 providerdoall
 -------------
 
-The providerdoall test repeated calls the OSSL_PROVIDER_do_all() function in
+The providerdoall test repeatedly calls the OSSL_PROVIDER_do_all() function in
 blocks of 100 calls, and 100 blocks per thread. The number of threads to use is
 provided as an argument and the test reports the average time take to execute a
 block of 100 OSSL_PROVIDER_do_all() calls.

--- a/perf/providerdoall.c
+++ b/perf/providerdoall.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <openssl/rand.h>
+#include <openssl/crypto.h>
+#include <openssl/provider.h>
+#include "perflib/perflib.h"
+
+#define NUM_CALLS_PER_BLOCK         100
+#define NUM_CALL_BLOCKS_PER_THREAD  100
+#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_THREAD)
+
+static int err = 0;
+
+static int doit(OSSL_PROVIDER *provider, void *vcount)
+{
+    int *count = vcount;
+
+    (*count)++;
+    return 1;
+}
+
+static void do_providerdoall(size_t num)
+{
+    int i;
+    unsigned char buf[32];
+    int count;
+
+    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+        count = 0;
+        if (!OSSL_PROVIDER_do_all(NULL, doit, &count) || count != 1) {
+            err = 1;
+            break;
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int threadcount;
+    OSSL_TIME duration;
+    uint64_t us;
+    double calltime;
+    int terse = 0;
+    int argnext;
+
+    if ((argc != 2 && argc != 3)
+                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
+        printf("Usage: providerdoall [--terse] threadcount\n");
+        return EXIT_FAILURE;
+    }
+
+    if (argc == 3) {
+        terse = 1;
+        argnext = 2;
+    } else {
+        argnext = 1;
+    }
+
+    threadcount = atoi(argv[argnext]);
+    if (threadcount < 1) {
+        printf("threadcount must be > 0\n");
+        return EXIT_FAILURE;
+    }
+
+    if (!perflib_run_multi_thread_test(do_providerdoall, threadcount, &duration)) {
+        printf("Failed to run the test\n");
+        return EXIT_FAILURE;
+    }
+
+    if (err) {
+        printf("Error during test\n");
+        return EXIT_FAILURE;
+    }
+
+    us = ossl_time2us(duration);
+
+    calltime = (double)us / (NUM_CALL_BLOCKS_PER_THREAD * threadcount);
+
+    if (terse)
+        printf("%lf\n", calltime);
+    else
+        printf("Total time divided by num blocks of %d OSSL_PROVIDER_do_all() calls: %lfus\n",
+               NUM_CALLS_PER_BLOCK, calltime);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This tests calls the OSSL_PROVIDER_do_all() function repeatedly in a loop.
This function can be called directly by user code, but is also used during
the initialisation of an SSL_CTX to discover TLS capabilities from
providers (e.g. pluggable groups etc).

The underlying internal function ossl_provider_doall_activated() will
also be tested by this. That function is called during algorithm fetching
(if the algorithms have not yet been cached).

This is built on the commits in https://github.com/openssl/tools/pull/146