### PR TITLE
release-tools/do-copyright-year: Always update copyright year in README.md

### DIFF
--- a/release-tools/do-copyright-year
+++ b/release-tools/do-copyright-year
@@ -27,44 +27,54 @@ s|(${some_year})-\1|\1|
 }
 EOF
 
-NYD=`date +%Y-01-01`
-echo Updating copryight
-git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
-    grep -v '^ *D' | \
-    (
-	count=0
-	sp="/-\|"
-	sc=0
-	spin() {
-	    printf "\r${sp:sc++:1} %s" "$@"
-	    ((sc==${#sp})) && sc=0
-	}
-	endspin() {
-	    printf "\r%s\n" "$@"
-	}
+collect_files() {
+    NYD=`date +%Y-01-01`
 
-	while read STATUS FILE ; do
-	    if [ -d "$FILE" ]; then continue; fi
-	    (( count++ ))
-	    spin $count
-	    # To avoid touching the original files when they aren't modified:
-	    #
-	    # 1. Copy the file, to make sure all permissions and other
-	    #	 copyable attributes are copied as well
-	    # 2. Run sed on the copy
-	    # 3. IF the copy has been modified, move it back to the original,
-	    #	 add and commit.
-	    TMPFILE="$(dirname "$FILE")"/"__$(basename "$FILE").new"
-	    cp "$FILE" "$TMPFILE"
-	    sed -E -f /tmp/sed$$ -i "$TMPFILE"
-	    if cmp -s "$FILE" "$TMPFILE"; then
-		rm "$TMPFILE"
-	    else
-		mv "$TMPFILE" "$FILE"
-		git add "$FILE"
-	    fi
-	done
-	endspin "Files considered: $count"
-    )
+    git diff-tree -r --name-status `git rev-list -1 --before=$NYD HEAD`..HEAD | \
+    grep -v '^ *D'
+
+    # Always update the end year in README.md. It might be listed twice,
+    # but this is hardly a problem, just slightly suboptimal.
+    echo 'X       README.md'
+}
+
+process_files() {
+    count=0
+    sp="/-\|"
+    sc=0
+    spin() {
+	printf "\r${sp:sc++:1} %s" "$@"
+	((sc==${#sp})) && sc=0
+    }
+    endspin() {
+	printf "\r%s\n" "$@"
+    }
+
+    while read STATUS FILE ; do
+	if [ -d "$FILE" ]; then continue; fi
+	(( count++ ))
+	spin $count
+	# To avoid touching the original files when they aren't modified:
+	#
+	# 1. Copy the file, to make sure all permissions and other
+	#	 copyable attributes are copied as well
+	# 2. Run sed on the copy
+	# 3. IF the copy has been modified, move it back to the original,
+	#	 add and commit.
+	TMPFILE="$(dirname "$FILE")"/"__$(basename "$FILE").new"
+	cp "$FILE" "$TMPFILE"
+	sed -E -f /tmp/sed$$ -i "$TMPFILE"
+	if cmp -s "$FILE" "$TMPFILE"; then
+	    rm "$TMPFILE"
+	else
+	    mv "$TMPFILE" "$FILE"
+	    git add "$FILE"
+	fi
+    done
+    endspin "Files considered: $count"
+}
+
+echo Updating copryight
+collect_files | process_files
 echo Files changed: $(git status --porcelain --untracked-files=no --ignore-submodules=all | grep '^ *M' | wc -l)
 rm -f $ss


### PR DESCRIPTION
The copyright in `README.md` is supposed to have global scope.

Fixes https://github.com/openssl/openssl/issues/20496#issuecomment-1465892773.