### PR TITLE
perf/pemread.c: Divide per-thread iteration count by threadcount

### DIFF
--- a/perf/README
+++ b/perf/README
@@ -41,16 +41,16 @@ labels.
 randbytes
 ---------
 
-The randbytes test repeated calls the RAND_bytes() function in blocks of 100
-calls, and 100 blocks per thread. The number of threads to use is provided as
-an argument and the test reports the average time take to execute a block of 100
-RAND_bytes() calls.
+The randbytes test does 10000 calls of the RAND_bytes() function divided
+evenly among multiple threads. The number of threads to use is provided as
+an argument and the test reports the average time take to execute a block of
+1000 RAND_bytes() calls.
 
 handshake
 ---------
 
-Performs a combined in-memory client and server handshake. Each thread performs
-1000 such handshakes. It takes 2 arguments:
+Performs a combined in-memory client and server handshake. In total 100000
+handshakes are performed divided evenly among each thread. It takes 2 arguments:
 
 certsdir - A directory where 2 files exist (servercert.pem and serverkey.pem) for
 the server certificate and key. The test/certs directory of the main OpenSSL
@@ -58,25 +58,28 @@ source repository contains such files for all supported branches.
 
 threadcount - The number of threads to perform handshakes on in the test
 
-The output is two values: the average time taken for a handshake in us, and the
-average handshakes per second performed over the course of the test.
+The output is two values: the average time taken for a single handshake in us,
+and the average number of simultaneous handshakes per second performed over the
+course of the test.
 
 sslnew
 ------
 
 The sslnew test repeatedly constructs a new SSL object and associates it with a
 newly constructed read BIO and a newly constructed write BIO, and finally frees
-them again. It does this in blocks of 100 sets of calls, and 100 blocks per
-threads. The number of threads to use is provided as an argument and the test
-reports the average time taken to execute a block of 100 construction/free calls.
+them again. It does 100000 repetitions divided evenly among each thread.
+The number of threads to use is provided as an argument and the test
+reports the average time taken to execute a block of 1000 construction/free
+calls.
 
 newrawkey
 ---------
 
 The newrawkey test repeatedly calls the EVP_PKEY_new_raw_public_key_ex()
-function in blocks of 100 calls, and 100 blocks per thread. The number of
-threads to use is provided as an argument and the test reports the average time
-take to execute a block of 100 EVP_PKEY_new_raw_public_key_ex() calls.
+function. It does 100000 repetitions divided evenly among each thread. The
+number of threads to use is provided as an argument and the test reports the
+average time take to execute a block of 1000 EVP_PKEY_new_raw_public_key_ex()
+calls.
 
 Note that this test does not support OpenSSL 1.1.1.
 
@@ -84,9 +87,9 @@ rsasign
 -------
 
 The rsasign test repeatedly calls the EVP_PKEY_sign_init()/EVP_PKEY_sign()
-functions in blocks of 100 calls, and 100 blocks per thread, using a 512 bit RSA
-key. The number of threads to use is provided as an argument and the test
-reports the average time take to execute a block of 100
+functions, using a 512 bit RSA key. It does 100000 repetitions divided evenly
+among each thread. The number of threads to use is provided as an argument and
+the test reports the average time take to execute a block of 1000
 EVP_PKEY_sign_init()/EVP_PKEY_sign() calls.
 
 x509storeissuer
@@ -97,12 +100,21 @@ is used in certificate chain building as part of a verify operation). The test
 assumes that the default certificates directly exists but is empty. For a
 default configuration this is "/usr/local/ssl/certs". The test takes the number
 of threads to use as an argument and the test reports the average time take to
-execute a block of 100 X509_STORE_CTX_get1_issuer() calls.
+execute a block of 1000 X509_STORE_CTX_get1_issuer() calls.
 
 providerdoall
 -------------
 
-The providerdoall test repeatedly calls the OSSL_PROVIDER_do_all() function in
-blocks of 100 calls, and 100 blocks per thread. The number of threads to use is
-provided as an argument and the test reports the average time take to execute a
-block of 100 OSSL_PROVIDER_do_all() calls.
+The providerdoall test repeatedly calls the OSSL_PROVIDER_do_all() function.
+It does 100000 repetitions divided evenly among each thread. The number of
+threads to use is provided as an argument and the test reports the average time
+take to execute a block of 1000 OSSL_PROVIDER_do_all() calls.
+
+pemread
+-------------
+
+The pemread test repeatedly calls the PEM_read_bio_PrivateKey() function on
+a memory BIO with a private RSA key. It does 100000 repetitions divided evenly
+among each thread. The number of threads to use is provided as an argument and
+the test reports the average time take to execute a block of 1000
+PEM_read_bio_PrivateKey() calls.

--- a/perf/pemread.c
+++ b/perf/pemread.c
@@ -34,6 +34,8 @@ const char *pemdataraw[] = {
     NULL
 };
 
+static int threadcount;
+
 void do_pemread(size_t num)
 {
     EVP_PKEY *key;
@@ -60,7 +62,7 @@ void do_pemread(size_t num)
      * Technically this includes the EVP_PKEY_free() in the timing - but I
      * think we can live with that
      */
-    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+    for (i = 0; i < NUM_CALLS_PER_THREAD / threadcount; i++) {
         key = PEM_read_bio_PrivateKey(pem, NULL, NULL, NULL);
         if (key == NULL) {
             printf("Failed to create key: %d\n", i);
@@ -77,7 +79,6 @@ void do_pemread(size_t num)
 
 int main(int argc, char *argv[])
 {
-    int threadcount;
     OSSL_TIME duration;
     uint64_t us;
     double avcalltime;
@@ -115,7 +116,7 @@ int main(int argc, char *argv[])
 
     us = ossl_time2us(duration);
 
-    avcalltime = (double)us / (NUM_CALL_BLOCKS_PER_THREAD * threadcount);
+    avcalltime = (double)us / NUM_CALL_BLOCKS_PER_THREAD;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/pemread.c
+++ b/perf/pemread.c
@@ -15,9 +15,10 @@
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
 
-#define NUM_CALLS_PER_BLOCK         100
-#define NUM_CALL_BLOCKS_PER_THREAD  100
-#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_THREAD)
+#define NUM_CALLS_PER_BLOCK         1000
+#define NUM_CALL_BLOCKS_PER_RUN     100
+#define NUM_CALLS_PER_RUN           (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_RUN)
+
 
 int err = 0;
 
@@ -62,7 +63,7 @@ void do_pemread(size_t num)
      * Technically this includes the EVP_PKEY_free() in the timing - but I
      * think we can live with that
      */
-    for (i = 0; i < NUM_CALLS_PER_THREAD / threadcount; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++) {
         key = PEM_read_bio_PrivateKey(pem, NULL, NULL, NULL);
         if (key == NULL) {
             printf("Failed to create key: %d\n", i);
@@ -116,7 +117,7 @@ int main(int argc, char *argv[])
 
     us = ossl_time2us(duration);
 
-    avcalltime = (double)us / NUM_CALL_BLOCKS_PER_THREAD;
+    avcalltime = (double)us / NUM_CALL_BLOCKS_PER_RUN;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/randbytes.c
+++ b/perf/randbytes.c
@@ -14,25 +14,26 @@
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
 
-#define NUM_CALLS_PER_BLOCK         100
-#define NUM_CALL_BLOCKS_PER_THREAD  100
-#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_THREAD)
+#define NUM_CALLS_PER_BLOCK         1000
+#define NUM_CALL_BLOCKS_PER_RUN     100
+#define NUM_CALLS_PER_RUN           (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_RUN)
 
 int err = 0;
+
+static int threadcount;
 
 void do_randbytes(size_t num)
 {
     int i;
     unsigned char buf[32];
 
-    for (i = 0; i < NUM_CALLS_PER_THREAD; i++)
+    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++)
         if (!RAND_bytes(buf, sizeof(buf)))
             err = 1;
 }
 
 int main(int argc, char *argv[])
 {
-    int threadcount;
     OSSL_TIME duration;
     uint64_t us;
     double avcalltime;
@@ -70,7 +71,7 @@ int main(int argc, char *argv[])
 
     us = ossl_time2us(duration);
 
-    avcalltime = (double)us / (NUM_CALL_BLOCKS_PER_THREAD * threadcount);
+    avcalltime = (double)us / NUM_CALL_BLOCKS_PER_RUN;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/sslnew.c
+++ b/perf/sslnew.c
@@ -14,12 +14,14 @@
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
 
-#define NUM_CALLS_PER_BLOCK         100
-#define NUM_CALL_BLOCKS_PER_THREAD  100
-#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_THREAD)
+#define NUM_CALLS_PER_BLOCK         1000
+#define NUM_CALL_BLOCKS_PER_RUN     100
+#define NUM_CALLS_PER_RUN           (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_RUN)
 
 int err = 0;
 static SSL_CTX *ctx;
+
+static int threadcount;
 
 void do_sslnew(size_t num)
 {
@@ -27,7 +29,7 @@ void do_sslnew(size_t num)
     SSL *s;
     BIO *rbio, *wbio;
 
-    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++) {
         s = SSL_new(ctx);
         rbio = BIO_new(BIO_s_mem());
         wbio = BIO_new(BIO_s_mem());
@@ -47,7 +49,6 @@ void do_sslnew(size_t num)
 
 int main(int argc, char *argv[])
 {
-    int threadcount;
     OSSL_TIME duration;
     uint64_t us;
     double avcalltime;
@@ -94,7 +95,7 @@ int main(int argc, char *argv[])
 
     us = ossl_time2us(duration);
 
-    avcalltime = (double)us / (NUM_CALL_BLOCKS_PER_THREAD * threadcount);
+    avcalltime = (double)us / NUM_CALL_BLOCKS_PER_RUN;
 
     if (terse)
         printf("%lf\n", avcalltime);


### PR DESCRIPTION
Otherwise with larger number of threads it takes too long to run.