### PR TITLE
add basic rw lock performance test

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -1,7 +1,7 @@
-all: randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall pemread
+all: randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall pemread rwlocks
 
 clean:
-	rm libperf.a *.o randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall pemread
+	rm libperf.a *.o randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall pemread rwlocks
 
 #-Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)
 
@@ -36,3 +36,6 @@ providerdoall:	providerdoall.c libperf.a
 
 pemread:	pemread.c libperf.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o pemread pemread.c -lperf -lcrypto
+
+rwlocks: rwlocks.c libperf.a
+	gcc $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o rwlocks rwlocks.c -lperf -lcrypto

--- a/perf/README
+++ b/perf/README
@@ -118,3 +118,12 @@ a memory BIO with a private RSA key. It does 100000 repetitions divided evenly
 among each thread. The number of threads to use is provided as an argument and
 the test reports the average time take to execute a block of 1000
 PEM_read_bio_PrivateKey() calls.
+
+rwlocks
+-------------
+the rwlocks test creates the command line specified number of threads, splitting
+them evenly between read and write functions (though this is adjustable via the
+LOCK_WRITERS environment variable).  Threads then iteratively acquire a shared
+rwlock to read or update some shared data.  The number of read and write
+lock/unlock pairs are reported as a performance measurement
+

--- a/perf/rwlocks.c
+++ b/perf/rwlocks.c
@@ -15,10 +15,7 @@
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
 
-#define NUM_CALLS_PER_BLOCK         1000
-#define NUM_CALL_BLOCKS_PER_THREAD  1000
-#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * \
-                                     NUM_CALL_BLOCKS_PER_THREAD)
+#define NUM_CALLS_PER_RUN 1000000
 
 int threadcount = 0;
 int err = 0;
@@ -38,7 +35,7 @@ void do_rw_wlock(size_t num)
     unsigned long *newval, *oldval;
     int local_write_lock_calls = 0;
 
-    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN/threadcount; i++) {
         newval = OPENSSL_malloc(sizeof(int));
         CRYPTO_THREAD_write_lock(lock);
         if (dataval == NULL)
@@ -68,7 +65,7 @@ void do_rw_rlock(size_t num)
     unsigned long last_val = 0;
     int local_read_lock_calls = 0;
 
-    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN/threadcount; i++) {
         CRYPTO_THREAD_read_lock(lock);
         if (dataval != NULL) {
             if (last_val != 0 && last_val > *dataval)

--- a/perf/rwlocks.c
+++ b/perf/rwlocks.c
@@ -35,7 +35,7 @@ void do_rw_wlock(size_t num)
     unsigned long *newval, *oldval;
     int local_write_lock_calls = 0;
 
-    for (i = 0; i < NUM_CALLS_PER_RUN/threadcount; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++) {
         newval = OPENSSL_malloc(sizeof(int));
         CRYPTO_THREAD_write_lock(lock);
         if (dataval == NULL)
@@ -65,7 +65,7 @@ void do_rw_rlock(size_t num)
     unsigned long last_val = 0;
     int local_read_lock_calls = 0;
 
-    for (i = 0; i < NUM_CALLS_PER_RUN/threadcount; i++) {
+    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++) {
         CRYPTO_THREAD_read_lock(lock);
         if (dataval != NULL) {
             if (last_val != 0 && last_val > *dataval)

--- a/perf/rwlocks.c
+++ b/perf/rwlocks.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include <openssl/crypto.h>
+#include "perflib/perflib.h"
+
+#define NUM_CALLS_PER_BLOCK         1000
+#define NUM_CALL_BLOCKS_PER_THREAD  1000
+#define NUM_CALLS_PER_THREAD        (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_THREAD)
+
+int threadcount = 0;
+int err = 0;
+unsigned long *dataval = NULL;
+int writers = 0;
+int readers = 0;
+int write_lock_calls = 0;
+int read_lock_calls = 0;
+OSSL_TIME reader_end = { 0 };
+OSSL_TIME writer_end = { 0 };
+
+CRYPTO_RWLOCK *lock = NULL;
+
+void do_rw_wlock(size_t num)
+{
+    int i;
+    unsigned long *newval, *oldval;
+    int local_write_lock_calls = 0;
+
+    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+        newval = OPENSSL_malloc(sizeof(int));        
+        CRYPTO_THREAD_write_lock(lock);
+        if (dataval == NULL)
+            *newval = 1;
+        else
+            *newval = ((*dataval) + 1);
+        oldval = dataval;
+        dataval = newval;
+        CRYPTO_THREAD_unlock(lock);
+        local_write_lock_calls += 2; /* lock and unlock */
+        OPENSSL_free(oldval);
+    }
+
+    CRYPTO_THREAD_write_lock(lock);
+    write_lock_calls += local_write_lock_calls;
+    writers--;
+    if (writers == 0)
+        writer_end = ossl_time_now();
+    CRYPTO_THREAD_unlock(lock); 
+}
+
+void do_rw_rlock(size_t num)
+{
+    int i;
+    unsigned long last_val = 0;
+    int local_read_lock_calls = 0;
+
+    for (i = 0; i < NUM_CALLS_PER_THREAD; i++) {
+        CRYPTO_THREAD_read_lock(lock);
+        if (dataval != NULL) {
+            if (last_val != 0 && last_val > *dataval)
+                printf("dataval went backwards! %lu:%lu\n", last_val, *dataval);
+            last_val = *dataval;
+        }
+        CRYPTO_THREAD_unlock(lock);
+        local_read_lock_calls += 2; /* lock and unlock */
+    }
+
+    CRYPTO_THREAD_write_lock(lock);
+    read_lock_calls += local_read_lock_calls;
+    readers--;
+    if (readers == 0)
+        reader_end = ossl_time_now();
+    CRYPTO_THREAD_unlock(lock);
+}
+
+void do_rwlocks(size_t num)
+{
+    if (num >= threadcount - writers)
+        do_rw_wlock(num);
+    else
+        do_rw_rlock(num);
+}
+
+int main(int argc, char *argv[])
+{
+    OSSL_TIME duration;
+    OSSL_TIME start;
+    uint64_t us;
+    double avwcalltime;
+    double avrcalltime;
+    int terse = 0;
+    int argnext;
+    char *writeenv;
+
+    if ((argc != 2 && argc != 3)
+       || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
+        printf("Usage: rwlocks [--terse] threadcount\n");
+        return EXIT_FAILURE;
+    }
+
+    if (argc == 3) {
+        terse = 1;
+        argnext = 2;
+    } else {
+        argnext = 1;
+    }
+
+    threadcount = atoi(argv[argnext]);
+    if (threadcount < 1) {
+        printf("threadcount must be > 0\n");
+        return EXIT_FAILURE;
+    }
+
+    writeenv=getenv("LOCK_WRITERS");
+    if (writeenv == NULL) {
+        writers = threadcount / 2;
+    } else {
+        writers=atoi(writeenv);
+        if (writers == 0)
+            writers = threadcount / 2;
+    }
+
+    lock = CRYPTO_THREAD_lock_new();
+    if (lock == NULL) {
+        printf("unable to allocate lock\n");
+        return EXIT_FAILURE;
+    }
+
+    readers = threadcount - writers;
+
+    if (!terse)
+        printf("Running rwlock test with %d writers and %d readers\n", writers, readers);
+
+    start = ossl_time_now(); 
+
+    if (!perflib_run_multi_thread_test(do_rwlocks, threadcount, &duration)) {
+        printf("Failed to run the test\n");
+        return EXIT_FAILURE;
+    }
+
+    if (err) {
+        printf("Error during test\n");
+        return EXIT_FAILURE;
+    }
+
+    us = ossl_time2us(ossl_time_subtract(writer_end, start));
+    avwcalltime = (double)us / (double)write_lock_calls;
+
+    if (!terse)
+        printf("total write lock/unlock calls %d in %lf us\n", write_lock_calls, (double)us);
+
+    us = ossl_time2us(ossl_time_subtract(reader_end, start));
+    avrcalltime = (double)us / (double)read_lock_calls;
+    if (!terse)
+        printf("total read lock/unlock calls %d %lf us\n", read_lock_calls, (double)us);
+
+    if (terse)
+        printf("%lf %lf\n", avwcalltime, avrcalltime);
+    else {
+        printf("Average time per CRYPTO_THREAD_write_lock/unlock call pair: %lfus\n",
+               avwcalltime);
+        printf("Average time per CRYPTO_THREAD_read_lock/unlock call pair: %lfus\n",
+               avrcalltime);
+    }
+
+    CRYPTO_THREAD_lock_free(lock);
+    return EXIT_SUCCESS;
+}

--- a/perf/x509storeissuer.c
+++ b/perf/x509storeissuer.c
@@ -65,7 +65,7 @@ static void do_x509storeissuer(size_t num)
 
 int main(int argc, char *argv[])
 {
-    int threadcount, i;
+    int i;
     OSSL_TIME duration, av;
     uint64_t us;
     double avcalltime;


### PR DESCRIPTION
Add a test to iteratively call [read|write] lock/unlock and see how many iterations we can get through for a given number of threads

Also accepts an environment variable LOCK_WRITERS to designate how many of the started threads should be write threads vs read threads