### PR TITLE
Allow for setting of extra cflags

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -3,30 +3,35 @@ all: randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall 
 clean:
 	rm libperf.a *.o randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall pemread
 
+#-Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)
+
+CFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
+LDFLAGS += -L$(TARGET_OSSL_LIBRARY_PATH) -L.
+
 libperf.a: perflib/*.c perflib/*.h
-	gcc -I$(TARGET_OSSL_INCLUDE_PATH) -I. -c perflib/*.c
+	gcc $(CFLAGS) -c perflib/*.c
 	ar rcs libperf.a *.o
 
 randbytes:	randbytes.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o randbytes randbytes.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o randbytes randbytes.c -lperf -lcrypto
 
 handshake: handshake.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o handshake handshake.c -lperf -lcrypto -lssl
+	gcc $(CFLAGS) $(LDFLAGS) -o handshake handshake.c -lperf -lcrypto -lssl
 
 sslnew: sslnew.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o sslnew sslnew.c -lperf -lcrypto -lssl
+	gcc $(CFLAGS) $(LDFLAGS) -o sslnew sslnew.c -lperf -lcrypto -lssl
 
 newrawkey:	newrawkey.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o newrawkey newrawkey.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o newrawkey newrawkey.c -lperf -lcrypto
 
 rsasign: rsasign.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o rsasign rsasign.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o rsasign rsasign.c -lperf -lcrypto
 
 x509storeissuer: x509storeissuer.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o x509storeissuer x509storeissuer.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o x509storeissuer x509storeissuer.c -lperf -lcrypto
 
 providerdoall:	providerdoall.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o providerdoall providerdoall.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o providerdoall providerdoall.c -lperf -lcrypto
 
 pemread:	pemread.c libperf.a
-	gcc -L$(TARGET_OSSL_LIBRARY_PATH) -L. -I$(TARGET_OSSL_INCLUDE_PATH) -I. -o pemread pemread.c -lperf -lcrypto
+	gcc $(CFLAGS) $(LDFLAGS) -o pemread pemread.c -lperf -lcrypto


### PR DESCRIPTION
When I build to run these tests under perf, I need to include a few extra cflags (notably -rpath an -fno-omit-frame-pointer).  They're not generally needed, but it would be nice to be able to set them easily in an environment.

Add CFLAGS and LDFLAGS support to allow for easy configuration