### PR TITLE
update ghmerge to python3

### DIFF
--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -152,7 +152,7 @@ if ! wget --quiet $PR_URL -O /tmp/gh$$; then
     echo "Error getting $PR_URL"
     exit 1
 fi
-set -- `python -c '
+set -- `python3 -c '
 from __future__ import print_function
 import json, sys;
 input = json.load(sys.stdin)


### PR DESCRIPTION
using ghmerge currently creates errors for me, in the form of inability to load various python packages, as fedora moved to python3 several releases ago

propose updating the use of python to python3 here to support recent distributions.