### PR TITLE
fix variable aliasing in x509storeissuer

### DIFF
--- a/perf/x509storeissuer.c
+++ b/perf/x509storeissuer.c
@@ -65,7 +65,7 @@ static void do_x509storeissuer(size_t num)
 
 int main(int argc, char *argv[])
 {
-    int threadcount, i;
+    int i;
     OSSL_TIME duration, av;
     uint64_t us;
     double avcalltime;


### PR DESCRIPTION
threadcount is defined globally and in main, which is fine, but doing so causes assignments to use the local scope rather than the global, which results in div-by-zero in the thread function when we divide NUM_CALLS by threadcount