### PR TITLE
Fix stats

### DIFF
--- a/perf/handshake.c
+++ b/perf/handshake.c
@@ -51,7 +51,7 @@ static void do_handshake(size_t num)
 int main(int argc, char *argv[])
 {
     double persec;
-    OSSL_TIME duration, av;
+    OSSL_TIME duration, ttime;
     uint64_t us;
     double avcalltime;
     char *cert;
@@ -109,19 +109,19 @@ int main(int argc, char *argv[])
         goto err;
     }
 
-    av = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        av = ossl_time_add(av, times[i]);
-    av = ossl_time_divide(av, NUM_HANDSHAKES_PER_RUN);
+        ttime = ossl_time_add(ttime, times[i]);
 
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_HANDSHAKES_PER_RUN) / (double)OSSL_TIME_US;
     persec = ((NUM_HANDSHAKES_PER_RUN * OSSL_TIME_SECOND)
              / (double)ossl_time2ticks(duration));
 
     if (terse) {
-        printf("%ld\n", ossl_time2us(av));
+        printf("%lf\n", avcalltime);
         printf("%lf\n", persec);
     } else {
-        printf("Average time per handshake: %ldus\n", ossl_time2us(av));
+        printf("Average time per handshake: %lfus\n", avcalltime);
         printf("Handshakes per second: %lf\n", persec);
     }
 

--- a/perf/newrawkey.c
+++ b/perf/newrawkey.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
     if (terse)
         printf("%lf\n", av);
     else
-        printf("Average time per EVP_PKEY_new_raw_public_key_ex() calls: %lfus\n",
+        printf("Average time per EVP_PKEY_new_raw_public_key_ex() call: %lfus\n",
                av);
 
     rc = EXIT_SUCCESS;

--- a/perf/newrawkey.c
+++ b/perf/newrawkey.c
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
      * and so because the average us computed above is less than
      * the value of OSSL_TIME_US, we wind up with truncation to
      * zero in the math.  Instead, manually do the division, casting
-     * our values as doubles so that we comput the proper time
+     * our values as doubles so that we compute the proper time
      */
     av = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) /(double)OSSL_TIME_US;
 

--- a/perf/newrawkey.c
+++ b/perf/newrawkey.c
@@ -51,7 +51,7 @@ void do_newrawkey(size_t num)
 int main(int argc, char *argv[])
 {
     OSSL_TIME duration;
-    OSSL_TIME us;
+    OSSL_TIME ttime;
     double av;
     int terse = 0;
     int argnext;
@@ -93,10 +93,9 @@ int main(int argc, char *argv[])
         goto out;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
     /*
      * EVP_PKEY_new_raw_public_key is pretty fast, running in
@@ -106,7 +105,7 @@ int main(int argc, char *argv[])
      * zero in the math.  Instead, manually do the division, casting
      * our values as doubles so that we comput the proper time
      */
-    av = (double)ossl_time2ticks(us)/(double)OSSL_TIME_US;
+    av = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) /(double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", av);

--- a/perf/pemread.c
+++ b/perf/pemread.c
@@ -86,7 +86,7 @@ void do_pemread(size_t num)
 int main(int argc, char *argv[])
 {
     OSSL_TIME duration;
-    OSSL_TIME us;
+    OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
     int argnext;
@@ -128,12 +128,11 @@ int main(int argc, char *argv[])
         goto out;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
-    avcalltime = (double)ossl_time2ticks(us) / (double)OSSL_TIME_US;
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) / (double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/pemread.c
+++ b/perf/pemread.c
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
     if (terse)
         printf("%lf\n", avcalltime);
     else
-        printf("Average time per PEM_read_bio_PrivateKey() calls: %lfus\n",
+        printf("Average time per PEM_read_bio_PrivateKey() call: %lfus\n",
                avcalltime);
 
     rc = EXIT_SUCCESS;

--- a/perf/providerdoall.c
+++ b/perf/providerdoall.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
     if (terse)
         printf("%lf\n", av);
     else
-        printf("Average time per OSSL_PROVIDER_do_all() calls: %lfus\n",
+        printf("Average time per OSSL_PROVIDER_do_all() call: %lfus\n",
                av);
 
     ret = EXIT_SUCCESS;

--- a/perf/providerdoall.c
+++ b/perf/providerdoall.c
@@ -54,7 +54,7 @@ static void do_providerdoall(size_t num)
 int main(int argc, char *argv[])
 {
     int i;
-    OSSL_TIME duration, us;
+    OSSL_TIME duration, ttime;
     double av;
     int terse = 0;
     int argnext;
@@ -95,12 +95,11 @@ int main(int argc, char *argv[])
         goto err;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
-    av = (double)ossl_time2ticks(us) / (double)OSSL_TIME_US;
+    av = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) / (double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", av);

--- a/perf/randbytes.c
+++ b/perf/randbytes.c
@@ -41,7 +41,7 @@ void do_randbytes(size_t num)
 int main(int argc, char *argv[])
 {
     OSSL_TIME duration;
-    OSSL_TIME us;
+    OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
     int argnext;
@@ -83,12 +83,11 @@ int main(int argc, char *argv[])
         goto out;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
-    avcalltime = (double)ossl_time2ticks(us) / (double)OSSL_TIME_US;
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) /(double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/rsasign.c
+++ b/perf/rsasign.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
     if (terse)
         printf("%lf\n", avcalltime);
     else
-        printf("Average time per RSA signature operations: %lfus\n",
+        printf("Average time per RSA signature operation: %lfus\n",
                avcalltime);
 
     rc = EXIT_SUCCESS;

--- a/perf/rsasign.c
+++ b/perf/rsasign.c
@@ -67,7 +67,7 @@ void do_rsasign(size_t num)
 int main(int argc, char *argv[])
 {
     OSSL_TIME duration;
-    OSSL_TIME us;
+    OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
     int argnext;
@@ -123,12 +123,11 @@ int main(int argc, char *argv[])
         goto out;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
-    avcalltime = (double)ossl_time2ticks(us) / (double)OSSL_TIME_US;
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) / (double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/sslnew.c
+++ b/perf/sslnew.c
@@ -55,7 +55,7 @@ void do_sslnew(size_t num)
 int main(int argc, char *argv[])
 {
     OSSL_TIME duration;
-    OSSL_TIME us;
+    OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
     int argnext;
@@ -103,12 +103,11 @@ int main(int argc, char *argv[])
         goto out;
     }
 
-    us = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        us = ossl_time_add(us, times[i]);
-    us = ossl_time_divide(us, NUM_CALLS_PER_TEST);
+        ttime = ossl_time_add(ttime, times[i]);
 
-    avcalltime = (double)ossl_time2ticks(us) / (double)OSSL_TIME_US;
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) / (double)OSSL_TIME_US;
 
     if (terse)
         printf("%lf\n", avcalltime);

--- a/perf/x509storeissuer.c
+++ b/perf/x509storeissuer.c
@@ -14,9 +14,7 @@
 #include <openssl/x509.h>
 #include "perflib/perflib.h"
 
-#define NUM_CALLS_PER_BLOCK         1000
-#define NUM_CALL_BLOCKS_PER_RUN     100
-#define NUM_CALLS_PER_RUN           (NUM_CALLS_PER_BLOCK * NUM_CALL_BLOCKS_PER_RUN)
+#define NUM_CALLS_PER_TEST         100000
 
 static int err = 0;
 static X509_STORE *store = NULL;
@@ -40,7 +38,7 @@ static void do_x509storeissuer(size_t num)
 
     start = ossl_time_now();
 
-    for (i = 0; i < NUM_CALLS_PER_RUN / threadcount; i++) {
+    for (i = 0; i < NUM_CALLS_PER_TEST / threadcount; i++) {
         /*
          * We actually expect this to fail. We've not configured any
          * certificates inside our store. We're just testing calling this
@@ -56,8 +54,7 @@ static void do_x509storeissuer(size_t num)
     }
 
     end = ossl_time_now();
-    times[num] = ossl_time_divide(ossl_time_subtract(end, start),
-                                  NUM_CALL_BLOCKS_PER_RUN);
+    times[num] = ossl_time_subtract(end, start);
 
  err:
     X509_STORE_CTX_free(ctx);
@@ -66,8 +63,7 @@ static void do_x509storeissuer(size_t num)
 int main(int argc, char *argv[])
 {
     int i;
-    OSSL_TIME duration, av;
-    uint64_t us;
+    OSSL_TIME duration, ttime;
     double avcalltime;
     int terse = 0;
     int argnext;
@@ -135,17 +131,20 @@ int main(int argc, char *argv[])
         goto err;
     }
 
-    av = times[0];
+    ttime = times[0];
     for (i = 1; i < threadcount; i++)
-        av = ossl_time_add(av, times[i]);
+        ttime = ossl_time_add(ttime, times[i]);
+
+    avcalltime = ((double)ossl_time2ticks(ttime) / (double)NUM_CALLS_PER_TEST) /(double)OSSL_TIME_US; 
 
     if (terse)
-        printf("%ld\n", ossl_time2us(av));
+        printf("%lf\n", avcalltime);
     else
-        printf("Average time per %d X509_STORE_CTX_get1_issuer() calls: %ldus\n",
-               NUM_CALLS_PER_BLOCK, ossl_time2us(av));
+        printf("Average time per X509_STORE_CTX_get1_issuer() call: %lfus\n",
+               avcalltime);
 
     ret = EXIT_SUCCESS;
+
  err:
     X509_STORE_free(store);
     X509_free(x509);


### PR DESCRIPTION
The stats measurements in the tools repo are inconsistent.  In some tests (like handshake) we measure each threads run time, add them and average them across the total numer of measured calls, while in others we just take the aggregate run time of the test.  And in many we average that by a random value that was at some time in the past meaningful (usually NUM_CALLS_PER_BLOCK), but is no longer useful, as most tests divide the number of calls to make across the number of threads being used.  Bring them all into line using a consistent measurement scheme:
1) For a given test, divide the number of calls by the threadcount
2) record the run time for each thread
3) after the threads complete, add each thread run time
4) divide the total aggregate thread execution time by the number of calls made

Also, because some tests are fast, don't use ossl_time2us() as that uses integer division to translate a number of ticks to us, which results loss of data when measurements take less than an average of 1us.  Instead use ossl_time2ticks, casting to a double to get the proper fractional value 