### PR TITLE
Add initital triage script

### DIFF
--- a/triage/README
+++ b/triage/README
@@ -1,0 +1,14 @@
+Openssl wrangler triage tools
+
+
+This is a set of tools that will enable individual executing the bug wrangler
+role to do their job (hopefully) more efficiently and consistently.  It creates
+a series of git extension to review bugs on the command line and process them in
+such a way that you don't need to remember all the individual steps you need to
+take to produce a particular outcome within our process.
+
+INSTALLATION
+Just add this directory to your PATH.  That will enable access to the following
+git extension:
+git triage
+

--- a/triage/git-triage
+++ b/triage/git-triage
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+    echo "No subcommand provided"
+    echo "Run git triage help for a list of commands"
+    exit 0
+fi
+
+SUBCOMMAND=$1
+shift
+
+which git-triage-$SUBCOMMAND > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+    TCMD=$(which git-triage)
+    TDIR=$(dirname $TCMD)
+    echo "Please select from the following subcommands:"
+    for i in $(ls $TDIR/git-triage-*)
+    do
+        CBASE=$(basename $i | sed -e"s/.*git-triage-//")
+        echo $CBASE
+    done
+    exit 1;
+fi
+
+
+exec git-triage-$SUBCOMMAND $*

--- a/triage/git-triage-evaluate
+++ b/triage/git-triage-evaluate
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+INSTDIR=$(dirname $0)
+source $INSTDIR/triage-common.sh
+
+
+VALID_TYPES=(bug feature documentation cleanup performance refactor question)
+TYPE=none
+
+ISSUE=unknown
+
+function parse_options {
+    # get the other options
+    while true
+    do
+        OPTION=$1
+        if [ -z "$OPTION" ]
+        then
+            return
+        fi
+        KEY=$(echo $1 | awk -F'=' '{print $1}')
+        VALUE=$(echo $1 | awk -F'=' '{print $2}')
+        case $KEY in
+        issue)
+            ISSUE=$VALUE
+            ;;
+        release)
+            RELEASE=$VALUE
+            ;;
+        target)
+            TARGET=$VALUE
+            ;;
+        resolution)
+            RESOLUTION=$VALUE
+            ;;
+        resolution_id)
+            RESOLUTION_ID=$VALUE
+            ;;
+        urgent)
+            IS_URGENT=$VALUE
+            ;;
+        important)
+            IS_IMPORTANT=$VALUE
+            ;;
+        regression)
+            IS_REGRESSION=$VALUE
+            ;;
+        priority)
+            PRIORITY=$VALUE
+            ;;
+        type)
+            TYPE=$VALUE
+            ;;
+        *)
+            echo "$KEY is not a valid option"
+            exit 1
+            ;;
+        esac
+        shift
+    done
+}
+
+function validate_target {
+    #check to ensure target is valid
+    for item in "${VALID_TARGETS[@]}"
+    do
+        if [ "$TARGET" == "$item" ]
+        then
+            return
+        fi
+    done
+    echo "please select target from one of [${VALID_TARGETS[@]}]"
+    exit 1
+}
+
+function validate_release {
+    for item in "${GH_RELEASE_LIST[@]}"
+    do
+        if [ "$RELEASE" == "$item" ]
+        then
+            return
+        fi
+    done
+    echo "please select a release from one of [${GH_RELEASE_LIST[@]}]"
+    exit 1
+}
+
+function validate_priority {
+    for item in "${VALID_PRIORITIES[@]}"
+    do
+        if [ "$PRIORITY" == "$item" ]
+        then
+            return
+        fi
+    done
+    echo "please select a priority from one of [${VALID_PRIORITIES[@]}]"
+    exit 1
+}
+
+function validate_issue {
+    gh issue view $ISSUE --json id >/dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+        echo "Unable to find issue $ISSUE"
+        exit 1;
+    fi
+}
+
+function validate_resolution {
+    for item in "${VALID_RESOLUTIONS[@]}"
+    do
+        if [ "$RESOLUTION" == "$item" ]
+        then
+            if [ "$RESOLUTION" == "duplicate" -a $RESOLUTION_ID -eq 0 ]
+            then
+                echo "A resolution of duplicate requires a resolution_id value"
+                exit 1
+            fi
+	    # map label names
+	    case "$RESOLUTION" in
+	    notabug)
+		RESOLUTION="not a bug"
+		;;
+	    wontfix)
+		RESOLUTION="wont fix"
+		;;
+	    *)
+		;;
+	    esac
+            return
+        fi
+    done
+    echo "$RESOLUTION is an invalid resolution value"
+    exit 1
+}
+
+function validate_type {
+    for item in "${VALID_TYPES[@]}"
+    do
+        if [ "$TYPE" == "$item" ]
+        then
+            return
+        fi
+    done
+    echo "please select an issue type from [${VALID_TYPES[@]}]"
+    exit 1
+}
+
+function validate_labels {
+    if [ "$IS_IMPORTANT" == "unknown" ]
+    then
+        echo "Please select important=[yes|no]"
+        exit 1
+    fi
+
+    if [ "$IS_REGRESSION" == "unknown" ]
+    then
+        echo "Please select regression=[yes|no]"
+        exit 1
+    fi
+}
+
+function validate_options {
+    validate_issue
+    validate_target
+    validate_type
+    validate_labels
+    if [ "$TARGET" == "openssl" ]
+    then
+        validate_release
+        validate_priority
+    fi
+    if [ "$TARGET" == "resolve" ]
+    then
+        validate_resolution
+    fi
+}
+
+function process_issue {
+    local labels
+
+    # Start by determining what label(s) we need
+    if [ "$TARGET" == "followup" ]
+    then
+        echo "Opening issue in a web browser so you can add a comment"
+        gh issue view $ISSUE -w
+        exit 0
+    fi
+
+    LABEL_LIST=""
+    # Add our triage labels
+    if [ "$IS_REGRESSION" == "yes" ]
+    then
+        LABEL_LIST="severity: regression"
+    fi
+    if [ "$IS_URGENT" == "yes" ]
+    then
+        LABEL_LIST="$LABEL_LIST,severity: urgent"
+    fi
+    if [ "$IS_IMPORTANT" == "yes" ]
+    then
+        LABEL_LIST="$LABEL_LIST,severity: important"
+    fi
+
+    LABEL_LIST="$LABEL_LIST,triaged: $TYPE"
+
+    if [ "$TARGET" == "community" ]
+    then
+        echo "Marking this issue as needing community resolution"
+        LABEL_LIST="$LABEL_LIST,help wanted"
+        LABEL_LIST=$(echo $LABEL_LIST | sed -e"s/^,\+//" -e"s/,\{2,\}/,/g" -e"s/,\+$//")
+        gh issue edit $ISSUE --add-label "$LABEL_LIST" 
+        exit 0
+    fi
+    if [ "$TARGET" == "resolve" ]
+    then
+        echo "Marking this issue as resolved with a resolution status of $RESOLUTION"
+        if [ "$RESOLUTION" == "duplicate" ]
+        then
+            gh issue comment $ISSUE --body "Marking this issue as a duplicate of #$RESOLUTION_ID"
+        fi
+        LABEL_LIST="$LABEL_LIST,resolved: $RESOLUTION"
+        LABEL_LIST=$(echo $LABEL_LIST | sed -e"s/^,\+//" -e"s/,\{2,\}/,/g" -e"s/,\+$//")
+        gh issue edit $ISSUE --add-label "$LABEL_LIST" 
+    fi
+    if [ "$TARGET" == "openssl" ]
+    then
+        echo "Marking this issue as needing openssl work"
+        LABEL_LIST=$(echo $LABEL_LIST | sed -e"s/^,\+//" -e"s/,\{2,\}/,/g" -e"s/,\+$//")
+        gh issue edit $ISSUE --add-label "$LABEL_LIST"
+        ISSUE_URL=$(gh issue view $ISSUE --json url --jq '.url')
+        echo "Adding issue to project board"
+        ISSUE_ID=$(gh project item-add --owner openssl 2 --url $ISSUE_URL --format json --jq '.id')
+        echo "Gathering project field info"
+        PROPOSED_RELEASE_ID=$(gh project field-list --owner openssl 2 --format json --jq ".fields[] | select(.name == \"Proposed Release\") | .options[] | select(.name == \"$RELEASE\") | .id")
+        PRIORITY_ID=$(gh project field-list --owner openssl 2 --format json --jq ".fields[] | select(.name == \"Priority\") | .options[] | select(.name == \"$PRIORITY\") | .id")
+
+        echo "Setting proposed release for issue"
+        gh project item-edit --id $ISSUE_ID --project-id $GH_PROJECT_ID --field-id $GH_PROPOSED_RELEASE_FIELD --single-select-option-id $PROPOSED_RELEASE_ID
+
+        echo "Setting priority for issue"
+        gh project item-edit --id $ISSUE_ID --project-id $GH_PROJECT_ID --field-id $GH_PRIORITY_FIELD --single-select-option-id $PRIORITY_ID
+    fi
+}
+
+tool_startup
+load_github_ids
+parse_options $*
+validate_options
+process_issue

--- a/triage/git-triage-help
+++ b/triage/git-triage-help
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+TMPFILE=$(mktemp /tmp/gittriage.XXXXXX)
+
+function cleanup {
+    rm -f $TMPFILE
+}
+
+trap cleanup EXIT
+
+cat << EOF > $TMPFILE
+.TH git-triage
+
+.SH NAME
+git triage \- list and evaluate issues in a repository
+
+.SH SYNOPSIS
+.B git triage [subcommand] [options]
+.RI
+
+.SH DESCRIPTION
+The git triage commands is intended to make the role of the bug wrangler in the
+openssl project easier and more consistent.  It is meant to isolate the
+determined disposition of an issue from the specific labels/states needed in a
+given issue to arrive at said disposition.  Ideally a user should be able to
+use this tool to list untriaged issues, set a determined disposition on an issue
+or request more information to make that determination.
+
+.SH SUBCOMMANDS
+.TP
+\fBhelp\fR
+Print this man page
+.TP
+\fBrefresh\fR
+Delete the git config stored project identifiers that are cached
+.TP
+\fBlist\fR
+List the untriaged issues in a repository
+.TP
+\fBvalues\fR
+List the currently available options for various values
+.TP
+\fBevaluate [options]\fR
+set the disposition of a given issue.  See options below for valid dispositions
+
+.SH EVALUATE OPTIONS
+.TP
+\fBissue=<number>\fR
+Select the issue to evaluate
+.TP
+\fBtype=[bug|feature|documentation|cleanup|performance|refactor|question]\fR
+Set the type of issue to triage this as
+.TP
+\fBurgent=[yes|no]\fR
+Boolean to indicate the issue is urgent (CI breakage). Defaults to no 
+.TP
+\fBimportant=[yes|no]\fR
+Boolean to indicate the issue is important.  Required
+.TP
+\fBregression=[yes|no]\fR
+Boolean to mark the issue as a regression. Required
+.TP
+\fBtarget=[openssl|community|followup|resolve]\fR
+.P
+Tells triage how to target the issue. If openssl is selected, then the issue
+will be placed on the backlog for openssl staff to evaluate further
+
+If community is selected, the issue will be marked as needing community
+contributions to complete
+
+If followup is selected, a comment is added to the issue requesting further
+input to properly evaluate the issue, and is left on the list of issues to
+triage
+
+If resolve is selected, the issues is labeled as resolved, but not closed.
+This label can be used in subsequent searches for closing later after a
+period of time has passed for the reporter to contest the resolution
+
+.TP
+\fBrelease=[<release selection>|future|list]\fR
+.P
+selects the target release for an issue.  Must be any of the defined release
+targets.  If future is selected, the issue is placed in the general backlog.
+If list is selected, the list of available releaes targets is printed and no
+action is taken
+EOF
+
+man $TMPFILE

--- a/triage/git-triage-list
+++ b/triage/git-triage-list
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+INSTDIR=$(dirname $0)
+source $INSTDIR/triage-common.sh
+
+tool_startup
+list_untriaged_issues
+

--- a/triage/git-triage-refresh
+++ b/triage/git-triage-refresh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+INSTDIR=$(dirname $0)
+source $INSTDIR/triage-common.sh
+
+tool_startup
+git config --local --unset triage.gh-project-id
+git config --local --unset triage.gh-proposed-release-field
+git config --local --unset triage.gh-priority-field
+git config --local --unset triage.gh-release-list
+echo "Cached project information flushed"
+

--- a/triage/git-triage-values
+++ b/triage/git-triage-values
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+INSTDIR=$(dirname $0)
+source $INSTDIR/triage-common.sh
+
+tool_startup
+load_github_ids
+
+echo "Valid Releases"
+echo "${GH_RELEASE_LIST[@]}"
+echo
+echo "Valid Types"
+echo "${VALID_TYPES[@]}"
+echo
+echo "Valid Targets"
+echo "${VALID_TARGETS[@]}"
+echo
+echo "Valid Resolutions"
+echo "${VALID_RESOLUTIONS[@]}"

--- a/triage/git-triage-view
+++ b/triage/git-triage-view
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+INSTDIR=$(dirname $0)
+source $INSTDIR/triage-common.sh
+
+tool_startup
+gh issue view -w $1
+

--- a/triage/triage-common.sh
+++ b/triage/triage-common.sh
@@ -1,0 +1,124 @@
+VALID_TARGETS=(openssl community followup resolve)
+TARGET=unknown
+
+VALID_RESOLUTIONS=(fixed wontfix duplicate notabug)
+RESOLUTION=none
+
+RESOLUTION_ID=0
+
+VALID_RELEASES=()
+RELEASE=none
+
+VALID_PRIORITIES=(Immediate High Medium Low)
+PRIORITY=low
+
+IS_URGENT=no
+IS_IMPORTANT=unknown
+IS_REGRESSION=unknown
+
+VALID_TYPES=(bug feature documentation cleanup performance refactor question)
+TYPE=none
+
+
+GH_PROJECT_ID=none
+GH_PROPOSED_RELEASE_FIELD=none
+GH_PRIORITY_FIELD=none
+GH_RELEASE_LIST=()
+
+function load_github_ids {
+    local i
+    git config --local --get-regexp triage > /dev/null 2>&1
+    if [ $? -eq 0 ]
+    then
+        # we have our cached values, load them
+        GH_PROJECT_ID=$(git config --local --get triage.gh-project-id)
+        GH_PROPOSED_RELEASE_FIELD=$(git config --local --get triage.gh-proposed-release-field)
+        GH_PRIORITY_FIELD=$(git config --local --get triage.gh-priority-field)
+        for i in $(git config --local --get triage.gh-release-list)
+        do
+            GH_RELEASE_LIST+=($i)
+        done
+    else
+        # We need to fetch and cache them
+        GH_PROJECT_ID=$(gh project list --owner openssl --format json --jq '.projects[] | select (.title == "Project Board") | .id')
+        git config --local triage.gh-project-id $GH_PROJECT_ID
+        GH_PROPOSED_RELEASE_FIELD=$(gh project field-list --owner openssl 2 --format json --jq '.fields[] | select(.name == "Proposed Release") | .id')
+        git config --local triage.gh-proposed-release-field $GH_PROPOSED_RELEASE_FIELD
+        GH_PRIORITY_FIELD=$(gh project field-list --owner openssl 2 --format json --jq '.fields[] | select(.name == "Priority") | .id')
+        git config --local triage.gh-priority-field $GH_PRIORITY_FIELD
+        CONFIG_LIST=""
+        for i in $(gh project field-list --owner openssl 2 --format json --jq '.fields[] | select(.name == "Proposed Release") | .options[] | .name')
+        do
+            GH_RELEASE_LIST+=($i)
+            CONFIG_LIST="$CONFIG_LIST $i"
+        done
+        git config --local triage.gh-release-list "$CONFIG_LIST" 
+    fi
+}
+
+needed_tools=(jq gh git)
+function check_tools {
+    local tool_pass=yes
+    for i in $(echo ${needed_tools[@]})
+    do
+        which $i > /dev/null 2>&1
+        if [ $? -ne 0 ]
+        then
+            echo "This tool requires $i to be installed"
+            tool_pass=no
+        fi
+    done
+
+    if [ "$tool_pass" == "no" ]
+    then
+        exit 1
+    fi
+}
+
+function check_gh_auth {
+    gh auth status > /dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+        echo "You are not logged into the github cli, attempting login"
+        if [ ! -f ~/.ghtoken ]
+        then
+            echo "You don't have an auth token in ~/.ghtoken"
+            echo "Create one by going to https://github.com/settings/tokens"
+            echo "And placing the generated token in ~/.ghtoken"
+            exit 1
+        fi
+        gh auth login --with-token < ~/.ghtoken
+    fi
+}
+
+function check_repo {
+    local selection
+    git config --get-regex remote | grep -q "gh-resolved"
+    if [ $? -ne 0 ]
+    then
+        echo "Please select one of the following repositories to triage:"
+        # Only display push repo urls, trimming leading protocol/host section of url
+        # and trailing .git.  thats what gh expects
+        git remote -v | awk '/(push)/ {print $2}' | sed -e"s/.*github.com[\:\/]*//" -e"s/\.git//"
+        echo "Please enter one of the above strings: "
+        read selection
+        gh repo set-default $selection > /dev/null 2>&1
+        if [ $? -ne 0 ]
+        then
+            echo "Failed to set default repository"
+            exit 1
+        fi
+    fi
+
+}
+
+# Prints a list of issues that don't have a triage label applied
+function list_untriaged_issues {
+    gh issue list --search '-label:"triaged: bug","triaged: feature","triaged: performance","triaged: refactor","triaged: question","triaged: documentation","triaged: cleanup","triaged: design"'
+}
+
+function tool_startup {
+    check_tools
+    check_gh_auth
+    check_repo
+}


### PR DESCRIPTION
In an effort to make triaging by the bug wrangler something that can be done in a single sweep, I'm proposing this set of git extensions to allow an issue to be triaged without having to remember the set of all labels/states/projects that need to be touched when doing so from the web interface