### PR TITLE
remove FTP mention

### DIFF
--- a/release-tools/release-aux/openssl-announce-pre-release.tmpl
+++ b/release-tools/release-aux/openssl-announce-pre-release.tmpl
@@ -17,12 +17,9 @@
 
         https://www.openssl.org/docs/manmaster/man7/migration_guide.html
 
-   The $label release is available for download via HTTPS and FTP from the
-   following master locations (you can find the various FTP mirrors under
-   https://www.openssl.org/source/mirror.html):
+   The $label release is available for download on this URL:
 
      * https://www.openssl.org/source/
-     * ftp://ftp.openssl.org/source/
 
    The distribution file name is:
 

--- a/release-tools/release-aux/openssl-announce-pre-release.tmpl
+++ b/release-tools/release-aux/openssl-announce-pre-release.tmpl
@@ -17,9 +17,10 @@
 
         https://www.openssl.org/docs/manmaster/man7/migration_guide.html
 
-   The $label release is available for download on this URL:
+   The $label release is available for download on these URLs:
 
      * https://www.openssl.org/source/
+     * https://github.com/openssl/openssl/releases
 
    The distribution file name is:
 

--- a/release-tools/release-aux/openssl-announce-pre-release.tmpl
+++ b/release-tools/release-aux/openssl-announce-pre-release.tmpl
@@ -17,7 +17,7 @@
 
         https://www.openssl.org/docs/manmaster/man7/migration_guide.html
 
-   The $label release is available for download on these URLs:
+   The $label release is available for download at these URLs:
 
      * https://www.openssl.org/source/
      * https://github.com/openssl/openssl/releases

--- a/release-tools/release-aux/openssl-announce-release-public.tmpl
+++ b/release-tools/release-aux/openssl-announce-release-public.tmpl
@@ -16,7 +16,7 @@
 
         https://www.openssl.org/docs/man$series/man7/migration_guide.html
 
-   OpenSSL $release is available for download on these URLs:
+   The OpenSSL $release is available for download at these URLs:
 
      * https://www.openssl.org/source/
      * https://github.com/openssl/openssl/releases

--- a/release-tools/release-aux/openssl-announce-release-public.tmpl
+++ b/release-tools/release-aux/openssl-announce-release-public.tmpl
@@ -16,12 +16,9 @@
 
         https://www.openssl.org/docs/man$series/man7/migration_guide.html
 
-   OpenSSL $release is available for download via HTTPS and FTP from the
-   following master locations (you can find the various FTP mirrors under
-   https://www.openssl.org/source/mirror.html):
+   OpenSSL $release is available for download on this URL:
 
      * https://www.openssl.org/source/
-     * ftp://ftp.openssl.org/source/
 
    The distribution file name is:
 

--- a/release-tools/release-aux/openssl-announce-release-public.tmpl
+++ b/release-tools/release-aux/openssl-announce-release-public.tmpl
@@ -16,9 +16,10 @@
 
         https://www.openssl.org/docs/man$series/man7/migration_guide.html
 
-   OpenSSL $release is available for download on this URL:
+   OpenSSL $release is available for download on these URLs:
 
      * https://www.openssl.org/source/
+     * https://github.com/openssl/openssl/releases
 
    The distribution file name is:
 


### PR DESCRIPTION
We shut down the FTP server and should not mention it in our release announcements.