### PR TITLE
Adjust Makefile for non-gnu OSes

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -5,33 +5,34 @@ clean:
 
 #-Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)
 
-CFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
+CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
+CFLAGS += -pthread
 LDFLAGS += -L$(TARGET_OSSL_LIBRARY_PATH) -L.
 
 libperf.a: perflib/*.c perflib/*.h
-	gcc $(CFLAGS) -c perflib/*.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c perflib/*.c
 	ar rcs libperf.a *.o
 
 randbytes:	randbytes.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o randbytes randbytes.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o randbytes randbytes.c -lperf -lcrypto
 
 handshake: handshake.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o handshake handshake.c -lperf -lcrypto -lssl
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o handshake handshake.c -lperf -lcrypto -lssl
 
 sslnew: sslnew.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o sslnew sslnew.c -lperf -lcrypto -lssl
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o sslnew sslnew.c -lperf -lcrypto -lssl
 
 newrawkey:	newrawkey.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o newrawkey newrawkey.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o newrawkey newrawkey.c -lperf -lcrypto
 
 rsasign: rsasign.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o rsasign rsasign.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o rsasign rsasign.c -lperf -lcrypto
 
 x509storeissuer: x509storeissuer.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o x509storeissuer x509storeissuer.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o x509storeissuer x509storeissuer.c -lperf -lcrypto
 
 providerdoall:	providerdoall.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o providerdoall providerdoall.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o providerdoall providerdoall.c -lperf -lcrypto
 
 pemread:	pemread.c libperf.a
-	gcc $(CFLAGS) $(LDFLAGS) -o pemread pemread.c -lperf -lcrypto
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o pemread pemread.c -lperf -lcrypto


### PR DESCRIPTION
Let Makefile to use CC variable to chose compiler conveniently. Rename current CFLAGS to CPPFLAGS.

Also we need to pass '-pthread' option on OpenBSD. The option is carried in CFLAGS now.