### PR TITLE
add support for installer repo to ghmerge

### DIFF
--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -42,6 +42,8 @@ foreach (@ARGV) {
         $args .= "--fuzz-corpora ";
     } elsif (/^--perftools$/) {
         $args .= "--perftools ";
+    } elsif (/^--installer/) {
+        $args .= "--installer ";
     } elsif (/^--verbose$/) {
         $args .= "--verbose ";
     } elsif (/^--noself$/) {

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -9,6 +9,7 @@ Option style arguments:
 
 --help              Print this help and exit
 --tools             Merge a tools PR (rather than openssl PR)
+--installer         Merge an installer PR (rather than openssl PR)
 --web               Merge a web PR (rather than openssl PR)
 --perftools         Merge a perftools PR (rather than openssl PR)
 --fuzz-corpora      Merge a PR against fuzz-corpora (rather than openssl PR)
@@ -63,6 +64,8 @@ while [ $# -ne 0 ]; do
         ;;
     --perftools)
         WHAT=perftools; BUILD=no; shift
+    --installer)
+        WHAT=installer ; BUILD=no ; shift
         ;;
     --technical-policies)
         WHAT=technical-policies ; BUILD=no ; shift

--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -148,12 +148,12 @@ foreach (@ARGV) {
         $min_omc = 0;
     } elsif (/--perftools$/) {
         $WHAT = 'perftools';
-        $min_authors = 2;
+        $min_authors = 1;
         $min_otc = 0;
         $min_omc = 0;
     } elsif (/--installer$/) {
         $WHAT = 'installer';
-        $min_authors = 2;
+        $min_authors = 1;
         # openssl/installer is governed by OTC
         $min_otc = 1;
         $min_omc = 0;

--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -150,9 +150,10 @@ foreach (@ARGV) {
         $WHAT = 'perftools';
         $min_authors = 2;
         $min_otc = 0;
+        $min_omc = 0;
     } elsif (/--installer$/) {
         $WHAT = 'installer';
-        $min_authors = 1;
+        $min_authors = 2;
         # openssl/installer is governed by OTC
         $min_otc = 1;
         $min_omc = 0;

--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -150,6 +150,11 @@ foreach (@ARGV) {
         $WHAT = 'perftools';
         $min_authors = 2;
         $min_otc = 0;
+    } elsif (/--installer$/) {
+        $WHAT = 'installer';
+        $min_authors = 1;
+        # openssl/installer is goverend by OTC
+        $min_otc = 1;
         $min_omc = 0;
     } elsif (/^--release$/) {
         $release = 1;

--- a/review-tools/gitaddrev
+++ b/review-tools/gitaddrev
@@ -153,7 +153,7 @@ foreach (@ARGV) {
     } elsif (/--installer$/) {
         $WHAT = 'installer';
         $min_authors = 1;
-        # openssl/installer is goverend by OTC
+        # openssl/installer is governed by OTC
         $min_otc = 1;
         $min_omc = 0;
     } elsif (/^--release$/) {


### PR DESCRIPTION
Adds installer repo as a merge WHAT target

Note also that I did some addional gymnastics to add OpenSSL-Query to the PERL5LIB path here to avoid having to copy those modules to the installer directory