### PR TITLE
This change hopes to provide a better alignement of pkeyread with other

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -1,9 +1,15 @@
-all: randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall rwlocks pkeyread evp_fetch
+PKEYREAD_SYMLINKS=pkeyread-dh-pem pkeyread-dhx-pem pkeyread-dsa-pem pkeyread-ec-pem pkeyread-rsa-pem pkeyread-x25519-pem \
+	pkeyread-dh-der pkeyread-dhx-der pkeyread-dsa-der pkeyread-ec-der pkeyread-rsa-der pkeyread-x25519-der
+all: randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall rwlocks pkeyread evp_fetch \
+	$(PKEYREAD_SYMLINKS)
+
 # Build target for OpenSSL 1.1.1 builds
-all111: randbytes handshake sslnew newrawkey rsasign x509storeissuer rwlocks pkeyread
+all111: randbytes handshake sslnew newrawkey rsasign x509storeissuer rwlocks pkeyread \
+	$(PKEYREAD_SYMLINKS)
 
 clean:
-	rm -f libperf.a *.o randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall rwlocks pkeyread evp_fetch
+	rm -f libperf.a *.o randbytes handshake sslnew newrawkey rsasign x509storeissuer providerdoall rwlocks pkeyread evp_fetch \
+	$(PKEYREAD_SYMLINKS)
 
 CPPFLAGS += -I$(TARGET_OSSL_INCLUDE_PATH) -I.
 # For second include path, i.e. out of tree build of OpenSSL uncomment this:
@@ -12,6 +18,8 @@ CFLAGS += -pthread
 LDFLAGS += -L$(TARGET_OSSL_LIBRARY_PATH) -L.
 # For setting RUNPATH on built executables uncomment this:
 # LDFLAGS += -Wl,-rpath,$(TARGET_OSSL_LIBRARY_PATH)
+
+LN=/bin/ln -s
 
 libperf.a: perflib/*.c perflib/*.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c perflib/*.c
@@ -49,3 +57,6 @@ regen_key_samples:
 
 pkeyread: pkeyread.c keys.h libperf.a
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o pkeyread pkeyread.c -lperf -lcrypto
+
+$(PKEYREAD_SYMLINKS): pkeyread
+	$(LN) pkeyread $@


### PR DESCRIPTION
performance tools we have. The pkeyread enables as to evaluate speed of reading various keys in der/pem formats. This requires user to specifi desired key and format on command line. This makes pkeyread different to other tools which seem to have a common set of options:
   ./tool_name --terse 2
command line above executes tool tool_name running test using 2 threads with terse output. The idea of this change is to provide implicit mode for pkeyread where key and format is determined from command name. For example to run evaulation for rsa key in pem format using 2 threads one runs tool:
   ./rsa.pem 2
The tool for rsa essentially becames a symlink to pkeyread binary.

This should help us to create us more simple shell scripts to run performacne test. For example to run all tests for pem keys we can do something like this in shell
for perf_tool in *.pem ; do
    ./$perf_tool --terse 2 ;
done