### PR TITLE
handshake and x509storeissuer tools also require a certsdir argument.

### DIFF
--- a/perf/evp_fetch.c
+++ b/perf/evp_fetch.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include <openssl/core_names.h>
@@ -183,22 +185,21 @@ int main(int argc, char *argv[])
     OSSL_TIME ttime;
     double av;
     int terse = 0;
-    int argnext;
     size_t i;
     int rc = EXIT_FAILURE;
     char *fetch_type = getenv("EVP_FETCH_TYPE");
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: %s [--terse] threadcount\n", argv[0]);
-        return EXIT_FAILURE;
-    }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
     }
 
     if (fetch_type != NULL) {
@@ -222,7 +223,11 @@ int main(int argc, char *argv[])
         }
     }
 
-    threadcount = atoi(argv[argnext]);
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
+        return EXIT_FAILURE;
+    }
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/newrawkey.c
+++ b/perf/newrawkey.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/evp.h>
 #include "perflib/perflib.h"
 
@@ -60,24 +62,27 @@ int main(int argc, char *argv[])
     OSSL_TIME ttime;
     double av;
     int terse = 0;
-    int argnext;
     size_t i;
     int rc = EXIT_FAILURE;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: newrawkey [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/pkeyread.c
+++ b/perf/pkeyread.c
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
@@ -197,7 +196,7 @@ static void usage(char * const argv[])
     const char **key_name = sample_names;
     const char **format_name = format_names;
 
-    fprintf(stderr, "%s -k key_name -f format_name [-t] thread_count\n"
+    fprintf(stderr, "%s -k key_name -f format_name [-t] terse threadcount\n"
         "\twhere key_name is one of these: ", argv[0]);
     fprintf(stderr, "%s", *key_name);
     do {
@@ -236,32 +235,11 @@ int main(int argc, char * const argv[])
         "PEM_read_bio_PrivateKey",
         "X509_PUBKEY_get0_param"
     };
-    struct option long_opts[] = {
-        {
-            "key",
-            required_argument,
-            NULL,
-            'k'
-        },
-        {
-            "format",
-            required_argument,
-            NULL,
-            'f'
-        },
-        {
-            "terse",
-            no_argument,
-            NULL,
-            't'
-        },
-        { 0 }
-    };
 
     key_id = SAMPLE_INVALID;
     format_id = FORMAT_INVALID;
 
-    while ((ch = getopt_long(argc, argv, "k:f:t", long_opts, NULL)) != -1) {
+    while ((ch = getopt(argc, argv, "k:f:t")) != -1) {
         switch (ch) {
         case 'k':
             key = optarg;

--- a/perf/providerdoall.c
+++ b/perf/providerdoall.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/rand.h>
 #include <openssl/crypto.h>
 #include <openssl/provider.h>
@@ -58,23 +60,26 @@ int main(int argc, char *argv[])
     OSSL_TIME duration, ttime;
     double av;
     int terse = 0;
-    int argnext;
     int ret = EXIT_FAILURE;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: providerdoall [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/randbytes.c
+++ b/perf/randbytes.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/rand.h>
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
@@ -45,24 +47,27 @@ int main(int argc, char *argv[])
     OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
-    int argnext;
     int rc = EXIT_FAILURE;
     size_t i;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: randbytes [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/rsasign.c
+++ b/perf/rsasign.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <assert.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>
@@ -71,25 +73,28 @@ int main(int argc, char *argv[])
     OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
-    int argnext;
     BIO *membio = NULL;
     int rc = EXIT_FAILURE;
     size_t i;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: rsasign [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/rwlocks.c
+++ b/perf/rwlocks.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
@@ -100,23 +102,26 @@ int main(int argc, char *argv[])
     double avwcalltime;
     double avrcalltime;
     int terse = 0;
-    int argnext;
     char *writeenv;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-        || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: rwlocks [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;

--- a/perf/sslnew.c
+++ b/perf/sslnew.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
+#include <unistd.h>
 #include <openssl/ssl.h>
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"
@@ -59,24 +61,27 @@ int main(int argc, char *argv[])
     OSSL_TIME ttime;
     double avcalltime;
     int terse = 0;
-    int argnext;
     int rc = EXIT_FAILURE;
     size_t i;
+    int opt;
 
-    if ((argc != 2 && argc != 3)
-                || (argc == 3 && strcmp("--terse", argv[1]) != 0)) {
-        printf("Usage: sslnew [--terse] threadcount\n");
+    while ((opt = getopt(argc, argv, "t")) != -1) {
+        switch (opt) {
+        case 't':
+            terse = 1;
+            break;
+        default:
+            printf("Usage: %s [-t] threadcount\n", basename(argv[0]));
+            printf("-t - terse output\n");
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (argv[optind] == NULL) {
+        printf("threadcount is missing\n");
         return EXIT_FAILURE;
     }
-
-    if (argc == 3) {
-        terse = 1;
-        argnext = 2;
-    } else {
-        argnext = 1;
-    }
-
-    threadcount = atoi(argv[argnext]);
+    threadcount = atoi(argv[optind]);
     if (threadcount < 1) {
         printf("threadcount must be > 0\n");
         return EXIT_FAILURE;


### PR DESCRIPTION
EDIT: Need to think first, then type.

we currently pass threadcount argument as the last argument in all tools. This is inconvenient because it tends to require special handling in scripts built on top of those tools. What I'd like to do is to move _threadcount_ argument which is common to all tools to first position. The _certsdir_ argument is currently used by `handshake` and `x509storeissuer` so it can be moved to second position. This will allow us to execute all tools with common set of options: `toolname --terse 8 /path/to/certsdir`, tool which does not require certsdir can ignore just ignore the next option.

this is simple change which is sufficient. Alternative approach would be to pass path to certificates via environment variable. This would be also fine with me. But I think we can save it for another day.