### PR TITLE
This change allows us to build perormance tools on Windows.

### DIFF
--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,77 @@
+#
+# make sure to set env. variables first:
+#	TARGET_OSSL_INCLUDE_PATH
+#		points to header files for desired version
+#	TARGET_OSSL_LIBRARY_PATH
+#		points to libraries with desired version
+#
+# to run performance test I suggest to build binaries outside of soruces.
+# run cmake as follows:
+#	cmake -S . -B ./build
+# option -B defines location of project files and resulting binaries.
+#
+# then you can build tools using cmake:
+#	cmake --build ./build
+#
+#
+
+cmake_minimum_required(VERSION 3.10)
+project(perf-tools)
+
+add_library(perf perflib/perfhelper.c perflib/perfsslhelper.c perflib/threads.c
+	perflib/time.c perflib/getopt.c perflib/basename.c perflib/strcasecmp.c)
+
+include_directories(PUBLIC $ENV{TARGET_OSSL_INCLUDE_PATH} . )
+
+find_package(Threads)
+link_libraries(${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(evp_fetch evp_fetch.c)
+target_include_directories(evp_fetch PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(evp_fetch PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(evp_fetch PUBLIC perf libcrypto)
+
+add_executable(randbytes randbytes.c)
+target_include_directories(randbytes PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(randbytes PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(randbytes PUBLIC perf libcrypto)
+
+add_executable(handshake handshake.c)
+target_include_directories(handshake PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(handshake PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(handshake PUBLIC perf libcrypto libssl)
+
+add_executable(sslnew sslnew.c)
+target_include_directories(sslnew PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(sslnew PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(sslnew PUBLIC perf libcrypto libssl)
+
+add_executable(newrawkey newrawkey.c)
+target_include_directories(newrawkey PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(newrawkey PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(newrawkey PUBLIC perf libcrypto)
+
+add_executable(rsasign rsasign.c)
+target_include_directories(rsasign PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(rsasign PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(rsasign PUBLIC perf libcrypto)
+
+add_executable(x509storeissuer x509storeissuer.c)
+target_include_directories(x509storeissuer PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(x509storeissuer PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(x509storeissuer PUBLIC perf libcrypto)
+
+add_executable(providerdoall providerdoall.c)
+target_include_directories(providerdoall PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(providerdoall PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(providerdoall PUBLIC perf libcrypto)
+
+add_executable(rwlocks rwlocks.c)
+target_include_directories(rwlocks PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(rwlocks PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(rwlocks PUBLIC perf libcrypto)
+
+add_executable(pkeyread pkeyread.c)
+target_include_directories(pkeyread PUBLIC "$(PROJECT_BINARY_DIR)" "$(PROJECT_SOURCE_DIR)")
+target_link_directories(pkeyread PUBLIC $ENV{TARGET_OSSL_LIBRARY_PATH})
+target_link_libraries(pkeyread PUBLIC perf libcrypto)

--- a/perf/evp_fetch.c
+++ b/perf/evp_fetch.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include <openssl/core_names.h>

--- a/perf/handshake.c
+++ b/perf/handshake.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/ssl.h>
 #include "perflib/perflib.h"
 
@@ -80,7 +86,6 @@ int main(int argc, char * const argv[])
 {
     double persec;
     OSSL_TIME duration, ttime;
-    uint64_t us;
     double avcalltime;
     int ret = EXIT_FAILURE;
     int i;

--- a/perf/newrawkey.c
+++ b/perf/newrawkey.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/evp.h>
 #include "perflib/perflib.h"
 

--- a/perf/perflib/basename.c
+++ b/perf/perflib/basename.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+
+/*
+ * windows variant of basename(3). works on ASCIIZ only.
+ * simple and perhaps naive implementation too.
+ */
+const char *
+basename(const char *path)
+{
+	const char *rv;
+
+	rv = (const char *)strrchr(path, '\\');
+	if (rv != NULL) {
+		rv++;
+		if (*rv == '\0')
+			rv = path;
+	}
+
+	return (rv);
+}

--- a/perf/perflib/basename.h
+++ b/perf/perflib/basename.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_PERFLIB_BASENAME_H
+# define OSSL_PERFLIB_BASENAME_H
+# pragma once
+
+extern const char *basename(const char *);
+
+#endif

--- a/perf/perflib/getopt.c
+++ b/perf/perflib/getopt.c
@@ -1,0 +1,52 @@
+/* *****************************************************************
+*
+* Copyright 2016 Microsoft
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************/
+
+#include "getopt.h"
+#include <windows.h>
+
+char* optarg = NULL;
+int optind = 1;
+
+int getopt(int argc, char *const argv[], const char *optstring)
+{
+    if ((optind >= argc) || (argv[optind][0] != '-') || (argv[optind][0] == 0))
+    {
+        return -1;
+    }
+
+    int opt = argv[optind][1];
+    const char *p = strchr(optstring, opt);
+
+    if (p == NULL)
+    {
+        return '?';
+    }
+    if (p[1] == ':')
+    {
+        optind++;
+        if (optind >= argc)
+        {
+            return '?';
+        }
+        optarg = argv[optind];
+        optind++;
+    }
+    return opt;
+}
+

--- a/perf/perflib/getopt.h
+++ b/perf/perflib/getopt.h
@@ -1,0 +1,37 @@
+/* *****************************************************************
+*
+* Copyright 2016 Microsoft
+*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************/
+
+#ifndef GETOPT_H__
+#define GETOPT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern char *optarg;
+extern int optind;
+
+int getopt(int argc, char *const argv[], const char *optstring);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/perf/perflib/strcasecmp.c
+++ b/perf/perflib/strcasecmp.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <ctype.h>
+
+int
+strcasecmp(const char *s1, const char *s2)
+{
+	if (s1 == NULL && s2 == NULL)
+		return (0);
+	if (s1 != NULL && s2 == NULL)
+		return (1);
+	if (s1 == NULL && s2 != NULL)
+		return (-1);
+
+	while ((*s1) && (tolower(*s1) == tolower(*s2))) {
+		s1++;
+		s2++;
+	}
+
+	return ((*s1 == *s2) ? 0 : (*s1 > *s2) ? 1 : -1);
+}

--- a/perf/perflib/strcasecmp.h
+++ b/perf/perflib/strcasecmp.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_PERFLIB_STRCASECMP_H
+# define OSSL_PERFLIB_STRCASECMP_H
+# pragma once
+
+extern const char *basename(const char *);
+
+#endif
+

--- a/perf/perflib/time.h
+++ b/perf/perflib/time.h
@@ -12,7 +12,12 @@
 # pragma once
 
 # include <openssl/e_os2.h>     /* uint64_t */
-# include "sys/time.h" /* TODO: Probably needs something else on Windows */
+# ifndef _WIN32
+#  include "sys/time.h"
+# else
+#  include <windows.h>
+#  include <winsock.h>
+# endif	/* _WIN32 */
 # include "safe_math.h"
 
 /*
@@ -81,7 +86,7 @@ OSSL_TIME ossl_time_infinite(void)
 
 /* Convert time to timeval */
 static ossl_unused ossl_inline
-struct timeval ossl_time_to_timeval(OSSL_TIME t)
+struct timeval ssl_time_to_timeval(OSSL_TIME t)
 {
     struct timeval tv;
 

--- a/perf/perflib/time.h
+++ b/perf/perflib/time.h
@@ -86,7 +86,7 @@ OSSL_TIME ossl_time_infinite(void)
 
 /* Convert time to timeval */
 static ossl_unused ossl_inline
-struct timeval ssl_time_to_timeval(OSSL_TIME t)
+struct timeval ossl_time_to_timeval(OSSL_TIME t)
 {
     struct timeval tv;
 

--- a/perf/pkeyread.c
+++ b/perf/pkeyread.c
@@ -10,7 +10,13 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/pem.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>

--- a/perf/providerdoall.c
+++ b/perf/providerdoall.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/rand.h>
 #include <openssl/crypto.h>
 #include <openssl/provider.h>
@@ -36,7 +42,6 @@ static int threadcount;
 static void do_providerdoall(size_t num)
 {
     size_t i;
-    unsigned char buf[32];
     int count;
     OSSL_TIME start, end;
 

--- a/perf/randbytes.c
+++ b/perf/randbytes.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif
 #include <openssl/rand.h>
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"

--- a/perf/rsasign.c
+++ b/perf/rsasign.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <assert.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>
@@ -45,7 +51,6 @@ static OSSL_TIME *times = NULL;
 void do_rsasign(size_t num)
 {
     size_t i;
-    unsigned char buf[32];
     unsigned char sig[64];
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(rsakey, NULL);
     size_t siglen = sizeof(sig);

--- a/perf/rwlocks.c
+++ b/perf/rwlocks.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/pem.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>

--- a/perf/sslnew.c
+++ b/perf/sslnew.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/ssl.h>
 #include <openssl/crypto.h>
 #include "perflib/perflib.h"

--- a/perf/x509storeissuer.c
+++ b/perf/x509storeissuer.c
@@ -10,8 +10,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _WIN32
 #include <libgen.h>
 #include <unistd.h>
+#else
+#include <windows.h>
+#include "perflib/getopt.h"
+#include "perflib/basename.h"
+#endif	/* _WIN32 */
 #include <openssl/bio.h>
 #include <openssl/x509.h>
 #include "perflib/perflib.h"


### PR DESCRIPTION
I've decided to use cmake to get it done.

The change also removes usused variables I've found occasionally.

To build performance tools on windows we must add missing pieces:
	- getopt() I took it from https://github.com/iotivity/iotivity according to comment it comes from Microsft license is apache 2.0
	- basename() and strcasecmp() implementations are homebrewed.