### PR TITLE
Support HTTPS repo address in ghmerge script

### DIFF
--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -144,7 +144,7 @@ else
 fi
 ADDREVOPTS=${ADDREVOPTS# } # chop any leading ' '
 
-[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk /$REMOTESRVR':(openssl|omc|otc).*(push)/{ print $1; }' | head -n 1` # usually this will be 'upstream'
+[ "$REMOTE" = "" ] && REMOTE=`git remote -v | awk /$REMOTESRVR'(:|\/)(openssl|omc|otc).*(push)/{ print $1; }' | head -n 1` # usually this will be 'upstream'
 if [ "$REMOTE" = "" ] ; then
     echo Cannot find git remote with URL including "$REMOTESRVR"
     exit 1


### PR DESCRIPTION
If git repository's address is in the HTTPS format, then the current ghmerge script doesn't work.

~~~
origin	https://github.openssl.org/openssl/openssl.git (fetch)
origin	https://github.openssl.org/openssl/openssl.git (push)
~~~

This patch fixes that.