### PR TITLE
`pick_to_branch`: add support for `openssl-3.6` target

### DIFF
--- a/review-tools/pick-to-branch
+++ b/review-tools/pick-to-branch
@@ -69,6 +69,9 @@ case $b in
 *3*5*)
     TARGET=openssl-3.5
     ;;
+*3*6*)
+    TARGET=openssl-3.6
+    ;;
 m*)
     TARGET=master
     ;;


### PR DESCRIPTION
SSIA