### PR TITLE
ghmerge: Add support for merging into security repo

### DIFF
--- a/review-tools/addrev
+++ b/review-tools/addrev
@@ -52,6 +52,8 @@ foreach (@ARGV) {
         $my_email = $1;
     } elsif (/^--nopr$/) {
         $haveprnum = 1;
+    } elsif (/^--security$/) {
+        $haveprnum = 1;
     } elsif (/^--commit=(.+)$/) {
         $args .= "--commit=$1 ";
     } elsif (/^--release$/) {

--- a/review-tools/ghmerge
+++ b/review-tools/ghmerge
@@ -13,6 +13,7 @@ Option style arguments:
 --web               Merge a web PR (rather than openssl PR)
 --perftools         Merge a perftools PR (rather than openssl PR)
 --fuzz-corpora      Merge a PR against fuzz-corpora (rather than openssl PR)
+--security          Merge a PR in the security repo
 --remote <remote>   Repo to merge with (rather than git.openssl.org), usually 'upstream'
 --target <branch>   Merge target (rather than current branch), usually 'master'
 --ref <branch>      A synonym for --target
@@ -73,6 +74,9 @@ while [ $# -ne 0 ]; do
         ;;
     --fuzz-corpora)
         WHAT=fuzz-corpora ; BUILD=no ; shift
+        ;;
+    --security)
+        WHAT=security ; REMOTESRVR="github.com" ; shift
         ;;
     --cherry-pick)
         shift;
@@ -155,10 +159,18 @@ if [ "$PRNUM" = "" -o "$TEAM" = "" ] ; then
 fi
 
 PR_URL_CONTENTS=$(mktemp /tmp/gh.XXXXXX)
-PR_URL=https://api.github.com/repos/openssl/$WHAT/pulls/$PRNUM
-if ! wget --quiet $PR_URL -O $PR_URL_CONTENTS; then
-    echo "Error getting $PR_URL"
-    exit 1
+PR_API=repos/openssl/$WHAT/pulls/$PRNUM
+PR_URL=https://api.github.com/$PR_API
+if which gh >/dev/null 2>&1 ; then
+    if ! gh api $PR_API >$PR_URL_CONTENTS; then
+        echo "Error getting $PR_API"
+        exit 1
+    fi
+else
+    if ! wget --quiet $PR_URL -O $PR_URL_CONTENTS; then
+        echo "Error getting $PR_URL"
+        exit 1
+    fi
 fi
 set -- `python3 -c '
 from __future__ import print_function
@@ -270,6 +282,10 @@ echo
 echo Diff against $REMOTE/$TARGET:
 git diff $REMOTE/$TARGET
 
+if [ "$WHAT" != "security" ] ; then
+    ADDPR="--prnum=$PRNUM"
+fi
+
 if [ "$INTERACTIVE" == "yes" ] ; then
     echo
     echo -n "Press Enter to interactively rebase $AUTOSQUASH on $REMOTE/$TARGET: "; read foo
@@ -281,8 +297,8 @@ if [ "$INTERACTIVE" == "yes" ] ; then
     fi
     REBASING=
     echo
-    echo "Calling addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$TARGET.."
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/$TARGET..
+    echo "Calling addrev $ADDREVOPTS $ADDPR $TEAM $REMOTE/$TARGET.."
+    addrev $ADDREVOPTS $ADDPR $TEAM $REMOTE/$TARGET..
 fi
 
 git checkout $TARGET
@@ -293,7 +309,7 @@ if [ "$INTERACTIVE" != "yes" ] ; then
     git merge --ff-only --no-commit --squash $WORK
     AUTHOR=`git show --no-patch --pretty="format:%an <%ae>" $WORK`
     git commit --author="$AUTHOR"
-    addrev $ADDREVOPTS --prnum=$PRNUM $TEAM $REMOTE/${TARGET}..
+    addrev $ADDREVOPTS $ADDPR $TEAM $REMOTE/${TARGET}..
 else
     # echo -n "Press Enter to merge to $TARGET: "; read foo
     echo


### PR DESCRIPTION
This is a private repo so no PR links and use `gh` to fetch the PR commits if available.